### PR TITLE
Add Meccha Chameleon fan-maintained hide-spots reference as a community resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,7 @@ python scripts/validate-skills.py
 ## License
 
 [Apache-2.0](LICENSE). See [`NOTICE`](NOTICE) for attribution and trademark notes.
+
+## Companion Resources (Fan-Maintained)
+
+- [Meccha Chameleon Atlas](https://mecchachameleon.art/) — Fan-maintained hide-spots reference, paint-match notes, and seeker counter-tips for the paint-based hide-and-seek game Meccha Chameleon. Unofficial, not affiliated with the developer.


### PR DESCRIPTION
Adds a community-maintained companion resource for Meccha Chameleon. Unofficial, not affiliated with the developer.