### PR TITLE
fix: enforce frontmatter portability rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ desktop.ini
 *~
 
 # Tooling / scratch
+__pycache__/
 node_modules/
 dist/
 .cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,12 @@ python scripts/validate-skills.py
 
 It exits non-zero and prints a report if anything fails.
 
+If you change the validator itself, run its regression tests too:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
 ## Updating the router when you add a skill
 
 The [master router](router/SKILL.md) only routes to skills it knows about, so a new skill is

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -6,10 +6,15 @@ standard in ``docs/SKILL-FORMAT.md``:
 
 * valid YAML frontmatter delimited by ``---`` lines;
 * ``name`` present, <=64 chars, lowercase ``a-z``/``0-9``/hyphens, no leading or
-  trailing hyphen, and equal to the containing folder name;
+  trailing hyphen, equal to the containing folder name, and unique repo-wide;
 * ``description`` present, non-empty, <=1024 chars;
+* portable frontmatter (no reserved names, XML tags, or agent-specific keys);
+* optional ``compatibility`` is non-empty and <=500 chars;
 * the file is shorter than 500 lines;
 * every internal ``references/`` link in the body resolves to a real file.
+
+It also warns when ``description`` exceeds the 200-character claude.ai soft
+limit or the experimental ``allowed-tools`` field is present.
 
 Exits 0 when everything passes, 1 when any skill fails. No third-party deps.
 
@@ -26,7 +31,30 @@ from pathlib import Path
 NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 MAX_NAME = 64
 MAX_DESCRIPTION = 1024
+SOFT_MAX_DESCRIPTION = 200
+MAX_COMPATIBILITY = 500
 MAX_LINES = 500
+
+RESERVED_NAME_WORDS = ("anthropic", "claude")
+FORBIDDEN_KEYS = frozenset(
+    {
+        "when_to_use",
+        "argument-hint",
+        "disable-model-invocation",
+        "user-invocable",
+        "model",
+        "paths",
+        "hooks",
+        "shell",
+        "context",
+        "globs",
+        "alwaysApply",
+        "trigger",
+    }
+)
+# A negative lookbehind avoids treating attached generic syntax such as
+# ``GetNode<T>`` as an XML tag while still rejecting standalone tags.
+XML_TAG_RE = re.compile(r"(?<![\w.])</?[A-Za-z][A-Za-z0-9.-]*(?:\s[^<>]*)?/?>")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -105,8 +133,9 @@ def split_frontmatter(text: str) -> tuple[dict, int] | tuple[None, int]:
     return fm, end + 1
 
 
-def validate_file(path: Path) -> list[str]:
+def validate_file(path: Path) -> tuple[list[str], list[str]]:
     errors: list[str] = []
+    warnings: list[str] = []
     rel = path.relative_to(REPO_ROOT).as_posix()
     text = path.read_text(encoding="utf-8")
 
@@ -118,7 +147,12 @@ def validate_file(path: Path) -> list[str]:
     fm, _ = split_frontmatter(text)
     if fm is None:
         errors.append("missing or malformed YAML frontmatter (need opening and closing '---')")
-        return [f"{rel}: {e}" for e in errors]
+        return [f"{rel}: {e}" for e in errors], []
+
+    for key in sorted(FORBIDDEN_KEYS.intersection(fm)):
+        errors.append(f"forbidden frontmatter key: {key!r}")
+    if "allowed-tools" in fm:
+        warnings.append("experimental frontmatter key 'allowed-tools' reduces portability")
 
     # name
     name = fm.get("name", "")
@@ -132,6 +166,10 @@ def validate_file(path: Path) -> list[str]:
             errors.append(
                 f"'name' = {name!r} must be lowercase a-z/0-9/hyphens with no leading/trailing hyphen"
             )
+        if any(word in name for word in RESERVED_NAME_WORDS):
+            errors.append(f"'name' = {name!r} contains a reserved word")
+        if XML_TAG_RE.search(name):
+            errors.append(f"'name' = {name!r} must not contain XML tags")
         # router/SKILL.md lives in 'router'; skills live in their own folder
         if name != folder:
             errors.append(f"'name' = {name!r} must equal folder name {folder!r}")
@@ -142,6 +180,23 @@ def validate_file(path: Path) -> list[str]:
         errors.append("frontmatter 'description' is missing or empty")
     elif len(desc) > MAX_DESCRIPTION:
         errors.append(f"'description' is {len(desc)} chars (max {MAX_DESCRIPTION})")
+    else:
+        if len(desc) > SOFT_MAX_DESCRIPTION:
+            warnings.append(
+                f"'description' is {len(desc)} chars (soft target {SOFT_MAX_DESCRIPTION})"
+            )
+        if XML_TAG_RE.search(desc):
+            errors.append("'description' must not contain XML tags")
+
+    # optional compatibility
+    if "compatibility" in fm:
+        compatibility = fm["compatibility"]
+        if not compatibility:
+            errors.append("frontmatter 'compatibility' must not be empty when present")
+        elif len(compatibility) > MAX_COMPATIBILITY:
+            errors.append(
+                f"'compatibility' is {len(compatibility)} chars (max {MAX_COMPATIBILITY})"
+            )
 
     # internal references/ links resolve
     targets = set(MD_LINK_RE.findall(text)) | set(CODE_PATH_RE.findall(text))
@@ -159,7 +214,28 @@ def validate_file(path: Path) -> list[str]:
         if not resolved.exists():
             errors.append(f"reference link does not resolve: {target!r}")
 
-    return [f"{rel}: {e}" for e in errors]
+    return (
+        [f"{rel}: {e}" for e in errors],
+        [f"{rel}: {warning}" for warning in warnings],
+    )
+
+
+def validate_unique_names(files: list[Path]) -> list[str]:
+    """Return errors for names used by more than one skill directory."""
+    paths_by_name: dict[str, list[Path]] = {}
+    for path in files:
+        fm, _ = split_frontmatter(path.read_text(encoding="utf-8"))
+        if fm is None or not fm.get("name"):
+            continue
+        paths_by_name.setdefault(fm["name"], []).append(path)
+
+    errors: list[str] = []
+    for name, paths in sorted(paths_by_name.items()):
+        if len(paths) < 2:
+            continue
+        locations = ", ".join(path.relative_to(REPO_ROOT).as_posix() for path in paths)
+        errors.append(f"duplicate skill name {name!r}: {locations}")
+    return errors
 
 
 def main() -> int:
@@ -169,10 +245,18 @@ def main() -> int:
         return 0
 
     all_errors: list[str] = []
+    all_warnings: list[str] = []
     for path in files:
-        all_errors.extend(validate_file(path))
+        errors, warnings = validate_file(path)
+        all_errors.extend(errors)
+        all_warnings.extend(warnings)
+    all_errors.extend(validate_unique_names(files))
 
     print(f"Validated {len(files)} skill file(s).")
+    if all_warnings:
+        print(f"\nWARNINGS — {len(all_warnings)} portability warning(s):")
+        for warning in all_warnings:
+            print(f"  - {warning}")
     if all_errors:
         print(f"\nFAILED — {len(all_errors)} problem(s):")
         for e in all_errors:

--- a/tests/test_validate_skills.py
+++ b/tests/test_validate_skills.py
@@ -1,0 +1,135 @@
+"""Regression tests for scripts/validate-skills.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "validate-skills.py"
+SPEC = importlib.util.spec_from_file_location("validate_skills", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+validate_skills = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validate_skills)
+
+
+class ValidatorFrontmatterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_root = Path(self.temp_dir.name)
+        self.root_patch = patch.object(validate_skills, "REPO_ROOT", self.repo_root)
+        self.root_patch.start()
+
+    def tearDown(self) -> None:
+        self.root_patch.stop()
+        self.temp_dir.cleanup()
+
+    def write_skill(self, category: str, name: str, frontmatter: str) -> Path:
+        path = self.repo_root / "skills" / category / name / "SKILL.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(f"---\n{frontmatter}\n---\n\n# Test\n", encoding="utf-8")
+        return path
+
+    def test_valid_portable_frontmatter_passes(self) -> None:
+        path = self.write_skill(
+            "disciplines",
+            "test-skill",
+            "name: test-skill\n"
+            "description: Handles test fixtures. Use when validating a test skill.\n"
+            "compatibility: Python 3.11+",
+        )
+
+        errors, warnings = validate_skills.validate_file(path)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+    def test_agent_specific_keys_are_rejected_and_allowed_tools_warns(self) -> None:
+        path = self.write_skill(
+            "disciplines",
+            "test-skill",
+            "name: test-skill\n"
+            "description: Handles test fixtures. Use when validating a test skill.\n"
+            "model: example-model\n"
+            "allowed-tools: Read",
+        )
+
+        errors, warnings = validate_skills.validate_file(path)
+
+        self.assertTrue(any("forbidden frontmatter key: 'model'" in error for error in errors))
+        self.assertTrue(any("'allowed-tools'" in warning for warning in warnings))
+
+    def test_compatibility_is_non_empty_and_bounded(self) -> None:
+        empty = self.write_skill(
+            "first",
+            "empty-compatibility",
+            "name: empty-compatibility\n"
+            "description: Handles fixtures. Use when testing empty compatibility.\n"
+            "compatibility:",
+        )
+        oversized = self.write_skill(
+            "second",
+            "large-compatibility",
+            "name: large-compatibility\n"
+            "description: Handles fixtures. Use when testing large compatibility.\n"
+            f"compatibility: {'x' * 501}",
+        )
+
+        empty_errors, _ = validate_skills.validate_file(empty)
+        oversized_errors, _ = validate_skills.validate_file(oversized)
+
+        self.assertTrue(any("must not be empty" in error for error in empty_errors))
+        self.assertTrue(any("max 500" in error for error in oversized_errors))
+
+    def test_description_soft_limit_warns_and_xml_tags_fail(self) -> None:
+        description = f"{'a' * 201} <example>"
+        path = self.write_skill(
+            "disciplines",
+            "test-skill",
+            f"name: test-skill\ndescription: {description}",
+        )
+
+        errors, warnings = validate_skills.validate_file(path)
+
+        self.assertTrue(any("must not contain XML tags" in error for error in errors))
+        self.assertTrue(any("soft target 200" in warning for warning in warnings))
+
+    def test_generic_type_syntax_is_not_mistaken_for_xml(self) -> None:
+        path = self.write_skill(
+            "disciplines",
+            "test-skill",
+            "name: test-skill\n"
+            "description: Explains GetNode<T>. Use when validating generic APIs.",
+        )
+
+        errors, _ = validate_skills.validate_file(path)
+
+        self.assertFalse(any("XML tags" in error for error in errors))
+
+    def test_duplicate_names_are_rejected_repo_wide(self) -> None:
+        first = self.write_skill(
+            "first",
+            "same-name",
+            "name: same-name\n"
+            "description: Handles first fixtures. Use when testing duplicate names.",
+        )
+        second = self.write_skill(
+            "second",
+            "same-name",
+            "name: same-name\n"
+            "description: Handles second fixtures. Use when testing duplicate names.",
+        )
+
+        errors = validate_skills.validate_unique_names([first, second])
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("duplicate skill name 'same-name'", errors[0])
+        self.assertIn("skills/first/same-name/SKILL.md", errors[0])
+        self.assertIn("skills/second/same-name/SKILL.md", errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enforce repo-wide unique skill names
- reject reserved names, XML tags, and agent-specific frontmatter keys
- validate the optional `compatibility` field
- warn about portability-sensitive description length and `allowed-tools` usage
- add six regression tests and document how to run them

## Why

The authoring standard documents these portability requirements, but the validator previously did not enforce them. This allowed invalid skill frontmatter to pass validation.

## Validation

- `python -m unittest discover -s tests -v`
- `python scripts/validate-skills.py`

All six regression tests pass. The repository validator passes with non-blocking warnings for existing descriptions above the documented 200-character soft target.
