### PR TITLE
feat(site): generate docs pages from skill frontmatter, add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate skills and run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate SKILL.md frontmatter and links
+        run: python scripts/validate-skills.py
+
+      - name: Run validator regression tests
+        run: python -m unittest discover -s tests -v
+
+      - name: Build the documentation site
+        run: python scripts/generate-site.py
+
+      - name: Check generated pages
+        run: python scripts/check-site.py

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy documentation site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - 'scripts/generate-site.py'
+      - 'scripts/check-site.py'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Let a queued run finish; never cancel a deploy mid-flight.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Generate pages from SKILL.md frontmatter
+        run: python scripts/generate-site.py --base-url "${{ steps.pages.outputs.base_url }}"
+
+      - name: Check generated pages
+        run: python scripts/check-site.py _site "${{ steps.pages.outputs.base_url }}"
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ desktop.ini
 
 # Tooling / scratch
 __pycache__/
+_site/
 node_modules/
 dist/
 .cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,16 @@ If you change the validator itself, run its regression tests too:
 python -m unittest discover -s tests -v
 ```
 
+The documentation site is generated from the same frontmatter, so a skill's page
+appears as soon as its `SKILL.md` is committed. To preview it locally:
+
+```bash
+python scripts/generate-site.py     # writes _site/ (git-ignored)
+python scripts/check-site.py        # per-page title/description/canonical checks
+```
+
+CI runs the validator, the tests and both site steps on every pull request.
+
 ## Updating the router when you add a skill
 
 The [master router](router/SKILL.md) only routes to skills it knows about, so a new skill is

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ claude plugin install godot@awesome-gamedev-agent-skills    # or: unity · unrea
 Prefer to copy the files by hand, or want the exact per-tool paths? See
 **[`docs/INSTALLATION.md`](docs/INSTALLATION.md)**.
 
+Want to read the catalog as web pages instead? Every skill, engine group, and per-agent install
+path is browsable at
+**[gamedev-skills.github.io/awesome-gamedev-agent-skills](https://gamedev-skills.github.io/awesome-gamedev-agent-skills/)**,
+generated straight from the `SKILL.md` files in this repo.
+
 Then just talk to your agent — see below.
 
 ## What you can ask
@@ -296,7 +301,8 @@ skills/        66 specialized skills, grouped by engine / discipline / genre / w
 router/        the master router skill (+ references/)
 docs/          authoring standard, installation, compatibility
 templates/     SKILL.md template
-scripts/       validate-skills.py and tooling
+scripts/       validate-skills.py, generate-site.py and tooling
+tests/         regression tests for the validator
 ```
 
 ## Contributing

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -1,0 +1,75 @@
+"""Verify the generated site: unique titles/descriptions, canonical correctness."""
+from __future__ import annotations
+
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+OUT = Path(sys.argv[1] if len(sys.argv) > 1 else "_site")
+BASE = (
+    sys.argv[2]
+    if len(sys.argv) > 2
+    else "https://gamedev-skills.github.io/awesome-gamedev-agent-skills"
+).rstrip("/")
+
+title_re = re.compile(r"<title>(.*?)</title>", re.S)
+desc_re = re.compile(r'<meta name="description" content="(.*?)">', re.S)
+canon_re = re.compile(r'<link rel="canonical" href="(.*?)">')
+
+pages = sorted(OUT.rglob("index.html"))
+titles, descs, problems = [], [], []
+
+for p in pages:
+    t = title_re.search(html := p.read_text(encoding="utf-8"))
+    d = desc_re.search(html)
+    c = canon_re.search(html)
+    rel = p.relative_to(OUT).parent.as_posix()
+    expect = f"{BASE}/" if rel == "." else f"{BASE}/{rel}/"
+
+    if not t or not t.group(1).strip():
+        problems.append(f"{rel}: missing title")
+    else:
+        titles.append(t.group(1).strip())
+    if not d or not d.group(1).strip():
+        problems.append(f"{rel}: missing description")
+    else:
+        descs.append(d.group(1).strip())
+        if len(d.group(1)) > 165:
+            problems.append(f"{rel}: description {len(d.group(1))} chars (>165)")
+    if not c:
+        problems.append(f"{rel}: missing canonical")
+    elif c.group(1) != expect:
+        problems.append(f"{rel}: canonical {c.group(1)!r} != {expect!r}")
+    if 'lang="en"' not in html:
+        problems.append(f"{rel}: missing lang attribute")
+    if 'class="skip"' not in html:
+        problems.append(f"{rel}: missing skip link")
+
+print(f"pages checked: {len(pages)}")
+print(f"unique titles: {len(set(titles))}/{len(titles)}")
+print(f"unique descriptions: {len(set(descs))}/{len(descs)}")
+
+for label, values in (("title", titles), ("description", descs)):
+    dupes = [v for v, n in Counter(values).items() if n > 1]
+    for v in dupes:
+        problems.append(f"duplicate {label}: {v[:80]!r}")
+
+sitemap = (OUT / "sitemap.xml").read_text(encoding="utf-8")
+locs = re.findall(r"<loc>(.*?)</loc>", sitemap)
+print(f"sitemap urls: {len(locs)} (unique {len(set(locs))})")
+canons = {canon_re.search(p.read_text(encoding='utf-8')).group(1) for p in pages}
+missing = canons - set(locs)
+if missing:
+    problems.append(f"{len(missing)} canonical URLs absent from sitemap")
+if not (OUT / "robots.txt").is_file():
+    problems.append("robots.txt missing")
+if not (OUT / "styles.css").is_file():
+    problems.append("styles.css missing")
+
+if problems:
+    print(f"\nFAILED — {len(problems)} problem(s):")
+    for pr in problems[:30]:
+        print(f"  - {pr}")
+    sys.exit(1)
+print("\nAll checks passed.")

--- a/scripts/generate-site.py
+++ b/scripts/generate-site.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Generate a static documentation site from the committed ``SKILL.md`` files.
+
+Every page is built from skill frontmatter, so the site cannot drift from the
+skills themselves. Unlike a ``blob`` view on github.com, each generated page
+carries its own ``<title>``, meta description and canonical URL.
+
+Output is written to ``_site/`` (git-ignored) and is deployed by
+``.github/workflows/pages.yml``. Nothing here mutates the skills.
+
+Usage:
+    python scripts/generate-site.py [--out _site] [--base-url URL]
+
+No third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import shutil
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUT = REPO_ROOT / "_site"
+DEFAULT_BASE_URL = "https://gamedev-skills.github.io/awesome-gamedev-agent-skills"
+REPO_SLUG = "gamedev-skills/awesome-gamedev-agent-skills"
+GITHUB_BLOB = f"https://github.com/{REPO_SLUG}/blob/main"
+INSTALL_CMD = f"npx skills add {REPO_SLUG}"
+
+MAX_META_DESCRIPTION = 155
+
+# Category slug -> (page heading, lead paragraph). Engine groups first.
+CATEGORIES: dict[str, tuple[str, str]] = {
+    "godot": (
+        "Godot Agent Skills",
+        "Skills that teach an AI coding agent the Godot 4.x API surface — GDScript, "
+        "the scene tree, TileMapLayer, physics, shaders and exporting.",
+    ),
+    "unity": (
+        "Unity Agent Skills",
+        "Skills covering Unity 6 (6000.0 LTS) — MonoBehaviour scripting, the Input "
+        "System, physics, Animator controllers, ScriptableObjects and builds.",
+    ),
+    "unreal": (
+        "Unreal Engine Agent Skills",
+        "Skills for Unreal Engine 5.4+ — Blueprints, C++ gameplay framework, "
+        "Enhanced Input, Behavior Trees, Niagara and packaging.",
+    ),
+    "web-engines": (
+        "Web Game Engine Agent Skills",
+        "Skills for browser game engines — Phaser 3, PixiJS v8 and three.js r165+.",
+    ),
+    "other-engines": (
+        "Bevy, pygame, LÖVE and Roblox Agent Skills",
+        "Skills for Bevy ECS, pygame, LÖVE and Roblox Luau, including DataStore "
+        "persistence.",
+    ),
+    "disciplines": (
+        "Game Development Discipline Skills",
+        "Cross-engine concepts that load alongside whichever engine skill applies — "
+        "AI, procedural generation, save systems, shaders, game feel and more.",
+    ),
+    "genres": (
+        "Game Genre Skills",
+        "Compositional templates that orchestrate engine and discipline skills for a "
+        "specific genre, from platformers to card games.",
+    ),
+    "workflows": (
+        "Game Development Workflow Skills",
+        "Skills for shipping — game jams, fast prototyping, and publishing to Steam "
+        "or itch.io.",
+    ),
+}
+
+# Agent slug -> (display name, skills directory, note)
+AGENTS: dict[str, tuple[str, str, str]] = {
+    "claude-code": ("Claude Code", ".claude/skills/", "Also installable as a Claude Code plugin marketplace."),
+    "cursor": ("Cursor", ".cursor/skills/", "Cursor also reads the shared .agents/skills/ path."),
+    "kiro": ("Kiro", ".kiro/skills/", "Kiro ignores the optional allowed-tools field; the skills here do not use it."),
+    "codex": ("OpenAI Codex", ".agents/skills/", "Shared path used by several agents."),
+    "gemini-cli": ("Gemini CLI", ".agents/skills/", "Shared path used by several agents."),
+    "github-copilot": ("GitHub Copilot", ".agents/skills/", "Shared path used by several agents."),
+    "windsurf": ("Windsurf", ".windsurf/skills/", ""),
+    "cline": ("Cline", ".cline/skills/", "Skills are experimental; enable them under Settings -> Features."),
+}
+
+
+# --------------------------------------------------------------------------- #
+# Frontmatter parsing (stdlib only; handles nested `metadata:` unlike the
+# validator's minimal parser, which only needs top-level keys).
+# --------------------------------------------------------------------------- #
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Return (frontmatter, body). Frontmatter values are str or dict[str, str]."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, text
+
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}, text
+
+    fm: dict = {}
+    key_re = re.compile(r"^([A-Za-z0-9_-]+):\s*(.*)$")
+    i = 1
+    while i < end:
+        raw = lines[i]
+        if not raw.strip() or raw.lstrip().startswith("#") or raw[:1] in (" ", "\t"):
+            i += 1
+            continue
+        m = key_re.match(raw)
+        if not m:
+            i += 1
+            continue
+        key, inline = m.group(1), m.group(2).strip()
+
+        if inline in (">", "|", ">-", "|-", ">+", "|+"):
+            block: list[str] = []
+            j = i + 1
+            while j < end and (not lines[j].strip() or lines[j][:1] in (" ", "\t")):
+                block.append(lines[j].strip())
+                j += 1
+            fm[key] = " ".join(part for part in block if part)
+            i = j
+            continue
+
+        if inline == "":
+            # Possibly a nested map (e.g. `metadata:`).
+            nested: dict[str, str] = {}
+            j = i + 1
+            while j < end and (lines[j][:1] in (" ", "\t")) and lines[j].strip():
+                sub = key_re.match(lines[j].strip())
+                if sub:
+                    nested[sub.group(1)] = sub.group(2).strip()
+                j += 1
+            fm[key] = nested if nested else ""
+            i = j
+            continue
+
+        fm[key] = inline
+        i += 1
+
+    return fm, "\n".join(lines[end + 1:])
+
+
+def first_heading(body: str) -> str:
+    for line in body.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return ""
+
+
+def meta_description(text: str, limit: int = MAX_META_DESCRIPTION) -> str:
+    """Trim to `limit` chars on a word boundary without cutting mid-word."""
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    cut = text[:limit].rsplit(" ", 1)[0].rstrip(" ,.;:—-")
+    return f"{cut}…"
+
+
+# --------------------------------------------------------------------------- #
+# Skill model
+# --------------------------------------------------------------------------- #
+
+class Skill:
+    def __init__(self, path: Path) -> None:
+        fm, body = parse_frontmatter(path.read_text(encoding="utf-8"))
+        meta = fm.get("metadata") or {}
+        if not isinstance(meta, dict):
+            meta = {}
+
+        self.path = path
+        self.name: str = str(fm.get("name", path.parent.name))
+        self.description: str = str(fm.get("description", ""))
+        self.compatibility: str = str(fm.get("compatibility", ""))
+        self.engine: str = meta.get("engine", "")
+        self.difficulty: str = meta.get("difficulty", "")
+        self.heading: str = first_heading(body) or self.name
+        self.category: str = meta.get("category", "") or path.parent.parent.name
+        self.rel_source: str = path.relative_to(REPO_ROOT).as_posix()
+
+    @property
+    def url_path(self) -> str:
+        return f"{self.category}/{self.name}/"
+
+
+def collect_skills() -> list[Skill]:
+    skills_dir = REPO_ROOT / "skills"
+    files = sorted(skills_dir.rglob("SKILL.md")) if skills_dir.is_dir() else []
+    return [Skill(p) for p in files]
+
+
+# --------------------------------------------------------------------------- #
+# HTML rendering
+# --------------------------------------------------------------------------- #
+
+STYLES = """\
+:root{--bg:#0d1117;--fg:#e6edf3;--muted:#9198a1;--accent:#7ee787;--line:#30363d;
+--code:#161b22}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);
+font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif}
+.skip{position:absolute;left:-9999px}
+.skip:focus{left:8px;top:8px;padding:8px 12px;background:var(--code);z-index:10}
+.wrap{max-width:56rem;margin:0 auto;padding:2rem 1.25rem 4rem}
+header nav{border-bottom:1px solid var(--line);padding:.9rem 0;margin-bottom:2rem}
+header nav a{margin-right:1rem}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+h1{font-size:1.9rem;line-height:1.25;margin:0 0 .6rem}
+h2{font-size:1.3rem;margin:2.2rem 0 .6rem}
+.lead{color:var(--muted);font-size:1.05rem;margin:0 0 1.6rem}
+pre{background:var(--code);border:1px solid var(--line);border-radius:6px;
+padding:.85rem 1rem;overflow-x:auto}
+code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.9em}
+table{border-collapse:collapse;width:100%;margin:1rem 0}
+th,td{border:1px solid var(--line);padding:.55rem .7rem;text-align:left;
+vertical-align:top}
+th{background:var(--code)}
+ul.cards{list-style:none;padding:0;display:grid;gap:.9rem}
+ul.cards li{border:1px solid var(--line);border-radius:6px;padding:.9rem 1.1rem}
+ul.cards p{margin:.35rem 0 0;color:var(--muted);font-size:.94rem}
+dl.facts{display:grid;grid-template-columns:auto 1fr;gap:.35rem 1rem;margin:1.2rem 0}
+dt{color:var(--muted)}
+dd{margin:0}
+footer{border-top:1px solid var(--line);margin-top:3rem;padding-top:1.2rem;
+color:var(--muted);font-size:.9rem}
+"""
+
+
+def page(
+    *,
+    title: str,
+    description: str,
+    canonical: str,
+    body: str,
+    depth: int,
+    base_url: str,
+) -> str:
+    root = "../" * depth if depth else ""
+    esc = html.escape
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{esc(title)}</title>
+<meta name="description" content="{esc(description)}">
+<link rel="canonical" href="{esc(canonical)}">
+<meta property="og:type" content="website">
+<meta property="og:title" content="{esc(title)}">
+<meta property="og:description" content="{esc(description)}">
+<meta property="og:url" content="{esc(canonical)}">
+<link rel="stylesheet" href="{root}styles.css">
+</head>
+<body>
+<a class="skip" href="#main">Skip to main content</a>
+<div class="wrap">
+<header>
+<nav aria-label="Primary">
+<a href="{root}">Catalog</a>
+<a href="{root}install/">Install</a>
+<a href="https://github.com/{REPO_SLUG}">Source on GitHub</a>
+</nav>
+</header>
+<main id="main">
+{body}
+</main>
+<footer>
+<p>Generated from the committed <code>SKILL.md</code> files by
+<code>scripts/generate-site.py</code>. Apache-2.0.</p>
+</footer>
+</div>
+</body>
+</html>
+"""
+
+
+def install_block(extra: str = "") -> str:
+    return (
+        "<h2>Install</h2>\n"
+        f"<pre><code>{html.escape(INSTALL_CMD)}</code></pre>\n"
+        f"{extra}"
+    )
+
+
+def skill_cards(skills: list[Skill], depth: int) -> str:
+    root = "../" * depth if depth else ""
+    items = []
+    for s in skills:
+        href = f"{root}{s.url_path}"
+        items.append(
+            f'<li><a href="{html.escape(href)}"><code>{html.escape(s.name)}</code></a>'
+            f"<p>{html.escape(meta_description(s.description, 180))}</p></li>"
+        )
+    return '<ul class="cards">\n' + "\n".join(items) + "\n</ul>"
+
+
+# --------------------------------------------------------------------------- #
+# Page builders
+# --------------------------------------------------------------------------- #
+
+def write(out: Path, rel: str, content: str) -> None:
+    target = out / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+
+def build_index(out: Path, skills: list[Skill], base_url: str) -> None:
+    by_cat: dict[str, list[Skill]] = {}
+    for s in skills:
+        by_cat.setdefault(s.category, []).append(s)
+
+    sections = []
+    for slug, (heading, lead) in CATEGORIES.items():
+        group = by_cat.get(slug, [])
+        if not group:
+            continue
+        sections.append(
+            f'<h2><a href="{slug}/">{html.escape(heading)}</a> '
+            f"<span class=\"muted\">({len(group)})</span></h2>\n"
+            f"<p>{html.escape(lead)}</p>"
+        )
+
+    body = (
+        "<h1>Game Development Agent Skills</h1>\n"
+        f'<p class="lead">{len(skills)} version-pinned Agent Skills plus a router, in the '
+        "portable <code>SKILL.md</code> format. An AI coding agent loads only the skills "
+        "that match the engine and task at hand.</p>\n"
+        + install_block(
+            '<p>Or copy any skill folder into your agent\'s skills directory — see '
+            '<a href="install/">install paths per agent</a>.</p>'
+        )
+        + "\n<h2>Catalog</h2>\n"
+        + "\n".join(sections)
+    )
+    write(
+        out,
+        "index.html",
+        page(
+            title="Game Development Agent Skills for AI Coding Agents",
+            description=meta_description(
+                f"{len(skills)} game dev agent skills for AI coding agents across Godot, "
+                "Unity, Unreal, Phaser, three.js, Bevy, pygame, LÖVE and Roblox."
+            ),
+            canonical=f"{base_url}/",
+            body=body,
+            depth=0,
+            base_url=base_url,
+        ),
+    )
+
+
+def build_category(out: Path, slug: str, skills: list[Skill], base_url: str) -> None:
+    heading, lead = CATEGORIES[slug]
+    body = (
+        f"<h1>{html.escape(heading)}</h1>\n"
+        f'<p class="lead">{html.escape(lead)}</p>\n'
+        + install_block()
+        + f"\n<h2>{len(skills)} skills</h2>\n"
+        + skill_cards(skills, depth=1)
+    )
+    write(
+        out,
+        f"{slug}/index.html",
+        page(
+            title=f"{heading} — {len(skills)} skills for AI coding agents",
+            description=meta_description(lead),
+            canonical=f"{base_url}/{slug}/",
+            body=body,
+            depth=1,
+            base_url=base_url,
+        ),
+    )
+
+
+def build_skill(out: Path, skill: Skill, siblings: list[Skill], base_url: str) -> None:
+    facts = [("Skill name", f"<code>{html.escape(skill.name)}</code>")]
+    if skill.compatibility:
+        facts.append(("Targets", html.escape(skill.compatibility)))
+    if skill.engine:
+        facts.append(("Engine", html.escape(skill.engine)))
+    if skill.difficulty:
+        facts.append(("Level", html.escape(skill.difficulty)))
+    facts_html = "\n".join(f"<dt>{k}</dt><dd>{v}</dd>" for k, v in facts)
+
+    related = [s for s in siblings if s.name != skill.name][:8]
+    related_html = ""
+    if related:
+        links = ", ".join(
+            f'<a href="../{html.escape(s.name)}/"><code>{html.escape(s.name)}</code></a>'
+            for s in related
+        )
+        related_html = f"<h2>Related skills</h2>\n<p>{links}</p>\n"
+
+    source = f"{GITHUB_BLOB}/{skill.rel_source}"
+    body = (
+        f"<h1>{html.escape(skill.heading)}</h1>\n"
+        f'<p class="lead">{html.escape(skill.description)}</p>\n'
+        f'<dl class="facts">\n{facts_html}\n</dl>\n'
+        + install_block(
+            f'<p>Installs every skill in the collection; the router loads '
+            f"<code>{html.escape(skill.name)}</code> when your request matches it.</p>"
+        )
+        + f'\n<h2>Skill source</h2>\n<p>Read the full playbook in '
+        f'<a href="{html.escape(source)}">{html.escape(skill.rel_source)}</a>.</p>\n'
+        + related_html
+    )
+    write(
+        out,
+        f"{skill.url_path}index.html",
+        page(
+            title=f"{skill.heading} — Agent Skill",
+            description=meta_description(skill.description),
+            canonical=f"{base_url}/{skill.url_path}",
+            body=body,
+            depth=2,
+            base_url=base_url,
+        ),
+    )
+
+
+def build_install_pages(out: Path, skills: list[Skill], base_url: str) -> None:
+    rows = "\n".join(
+        f'<tr><td><a href="{slug}/">{html.escape(nameinfo[0])}</a></td>'
+        f"<td><code>{html.escape(nameinfo[1])}</code></td></tr>"
+        for slug, nameinfo in AGENTS.items()
+    )
+    body = (
+        "<h1>Install game dev agent skills</h1>\n"
+        '<p class="lead">One command detects the coding agent you already use and writes '
+        "the router plus every skill to the right directory.</p>\n"
+        + install_block()
+        + "\n<h2>Skills directory per agent</h2>\n"
+        f"<table>\n<thead><tr><th>Agent</th><th>Skills directory</th></tr></thead>\n"
+        f"<tbody>\n{rows}\n</tbody>\n</table>"
+    )
+    write(
+        out,
+        "install/index.html",
+        page(
+            title="Install game dev agent skills in any AI coding agent",
+            description=meta_description(
+                "Install game development agent skills into Claude Code, Cursor, Kiro, "
+                "Codex, Gemini CLI, Copilot, Windsurf or Cline with one command."
+            ),
+            canonical=f"{base_url}/install/",
+            body=body,
+            depth=1,
+            base_url=base_url,
+        ),
+    )
+
+    for slug, (display, directory, note) in AGENTS.items():
+        note_html = f"<p>{html.escape(note)}</p>\n" if note else ""
+        body = (
+            f"<h1>Install game dev agent skills in {html.escape(display)}</h1>\n"
+            f'<p class="lead">Add {len(skills)} version-pinned game development skills '
+            f"and a router to {html.escape(display)}. The router detects your engine from "
+            "the project files and loads only the skills that fit the request.</p>\n"
+            + install_block(
+                f'<p>The CLI writes to <code>{html.escape(directory)}</code>. '
+                f"To install by hand, copy a skill's folder into that directory.</p>\n"
+                + note_html
+            )
+            + '\n<h2>Browse the skills</h2>\n<p>'
+            + ", ".join(
+                f'<a href="../../{slug2}/">{html.escape(CATEGORIES[slug2][0])}</a>'
+                for slug2 in CATEGORIES
+            )
+            + "</p>"
+        )
+        write(
+            out,
+            f"install/{slug}/index.html",
+            page(
+                title=f"Game dev agent skills for {display} — install guide",
+                description=meta_description(
+                    f"Install {len(skills)} game development agent skills in {display}. "
+                    f"Skills live in {directory} and cover Godot, Unity, Unreal and web engines."
+                ),
+                canonical=f"{base_url}/install/{slug}/",
+                body=body,
+                depth=2,
+                base_url=base_url,
+            ),
+        )
+
+
+def build_sitemap(out: Path, urls: list[str], base_url: str) -> None:
+    today = date.today().isoformat()
+    entries = "\n".join(
+        f"  <url><loc>{html.escape(u)}</loc><lastmod>{today}</lastmod></url>" for u in urls
+    )
+    write(
+        out,
+        "sitemap.xml",
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        f"{entries}\n</urlset>\n",
+    )
+    write(
+        out,
+        "robots.txt",
+        f"User-agent: *\nAllow: /\n\nSitemap: {base_url}/sitemap.xml\n",
+    )
+
+
+# --------------------------------------------------------------------------- #
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default=str(DEFAULT_OUT), help="output directory")
+    ap.add_argument("--base-url", default=DEFAULT_BASE_URL, help="canonical base URL")
+    args = ap.parse_args()
+
+    base_url = args.base_url.rstrip("/")
+    out = Path(args.out)
+    if out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True)
+
+    skills = collect_skills()
+    if not skills:
+        print("No SKILL.md files found under skills/.")
+        return 1
+
+    by_cat: dict[str, list[Skill]] = {}
+    for s in skills:
+        by_cat.setdefault(s.category, []).append(s)
+
+    unknown = sorted(set(by_cat) - set(CATEGORIES))
+    if unknown:
+        print(f"FAILED — skills use unknown category values: {', '.join(unknown)}")
+        return 1
+
+    urls = [f"{base_url}/", f"{base_url}/install/"]
+
+    build_index(out, skills, base_url)
+    build_install_pages(out, skills, base_url)
+    urls += [f"{base_url}/install/{slug}/" for slug in AGENTS]
+
+    for slug, group in by_cat.items():
+        build_category(out, slug, group, base_url)
+        urls.append(f"{base_url}/{slug}/")
+        for skill in group:
+            build_skill(out, skill, group, base_url)
+            urls.append(f"{base_url}/{skill.url_path}")
+
+    write(out, "styles.css", STYLES)
+    build_sitemap(out, urls, base_url)
+
+    print(f"Generated {len(urls)} pages for {len(skills)} skills into {out}/")
+    print(f"Categories: {', '.join(f'{k}={len(v)}' for k, v in sorted(by_cat.items()))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Publishes the catalog as browsable web pages generated from `SKILL.md` frontmatter, and puts the validator under CI for the first time.

Additive only — **no `SKILL.md` file is touched**, so installing and routing are unchanged and the existing repository pages keep every signal they have today.

## Why

The catalog is discoverable through exactly one URL. That's structural, not editorial:

- `github.com/robots.txt` contains `Disallow: /*/tree/`, so every folder view (`skills/godot/`, `skills/genres/`, …) is closed to crawlers.
- `/blob/` paths are crawlable, but GitHub generates their metadata. Fetching `skills/godot/godot-tilemap/SKILL.md` returns `title = "awesome-gamedev-agent-skills/skills/godot/godot-tilemap/SKILL.md at main · …"` and a `description` equal to the repository About text. All 67 files therefore share one description and a path-shaped title, and none of it can be set from this repo.

So a reader looking for the Godot skills, or the Kiro install path, has no page to land on. This adds those pages.

## What's here

| File | Purpose |
|------|---------|
| `scripts/generate-site.py` | Builds 84 pages into git-ignored `_site/` from frontmatter alone: catalog index, 8 category hubs, 66 skill pages, install index + 8 per-agent install pages, `sitemap.xml`, `robots.txt`, stylesheet |
| `scripts/check-site.py` | Asserts unique titles/descriptions, canonical correctness, sitemap coverage, `lang` attribute, skip link |
| `.github/workflows/ci.yml` | Validator + `tests/` + site build + site check on push/PR — the repo's first CI |
| `.github/workflows/pages.yml` | Builds and deploys to GitHub Pages; base URL from `actions/configure-pages` |

Each page gets its own `<title>`, meta description and canonical URL — the three things github.com doesn't let us set. Page headings are taken from each skill's own first `#` heading, so pages can't drift from the skills. Stdlib only, matching the existing validator.

The generator fails closed: an unrecognised `metadata.category` aborts the build rather than silently dropping a skill.

## Validation

```
python scripts/validate-skills.py     # Validated 67 skill file(s). All checks passed.
python -m unittest discover -s tests  # Ran 6 tests. OK
python scripts/generate-site.py       # Generated 84 pages for 66 skills
python scripts/check-site.py          # 84/84 unique titles, 84/84 unique descriptions, 84 sitemap urls
```

Category counts from the build: `godot=15, unity=8, unreal=6, web-engines=6, other-engines=5, disciplines=13, genres=9, workflows=4`.

Also verified the `--base-url` plumbing that CI uses by building against a substitute host and re-running the checker against it.

## Before merging

GitHub Pages needs **Settings → Pages → Source: GitHub Actions**, otherwise the deploy job has nothing to publish to. The README link added here goes live with the first successful deploy.
