### PR TITLE
feat(roblox): expand UI, networking, character, physics, and Studio coverage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "gamedev",
       "source": "./",
-      "description": "Everything: the master router plus all 67 game-dev skills across every engine, discipline, genre, and workflow.",
+      "description": "Everything: the master router plus all 72 game-dev skills across every engine, discipline, genre, and workflow.",
       "strict": false,
       "skills": [
         "./router",
@@ -52,6 +52,11 @@
         "./skills/other-engines/love2d-core",
         "./skills/other-engines/roblox-luau",
         "./skills/other-engines/roblox-datastores",
+        "./skills/other-engines/roblox-ui",
+        "./skills/other-engines/roblox-networking",
+        "./skills/other-engines/roblox-characters",
+        "./skills/other-engines/roblox-physics",
+        "./skills/other-engines/roblox-studio-workflow",
         "./skills/disciplines/create-game-assets",
         "./skills/disciplines/game-ai",
         "./skills/disciplines/procedural-gen",
@@ -161,13 +166,18 @@
       "name": "other-engines",
       "source": "./",
       "strict": false,
-      "description": "Bevy, pygame, LÖVE, and Roblox engine skills.",
+      "description": "Bevy, pygame, LÖVE, and production-focused Roblox engine skills.",
       "skills": [
         "./skills/other-engines/bevy-ecs",
         "./skills/other-engines/pygame-core",
         "./skills/other-engines/love2d-core",
         "./skills/other-engines/roblox-luau",
-        "./skills/other-engines/roblox-datastores"
+        "./skills/other-engines/roblox-datastores",
+        "./skills/other-engines/roblox-ui",
+        "./skills/other-engines/roblox-networking",
+        "./skills/other-engines/roblox-characters",
+        "./skills/other-engines/roblox-physics",
+        "./skills/other-engines/roblox-studio-workflow"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 
 <p align="center">
   <img src="docs/assets/banner.png" width="820"
-       alt="awesome-gamedev-agent-skills — game-dev skills for AI coding agents. 67 skills and a router across 10 engines, including an art-direction and asset-production workflow.">
+       alt="awesome-gamedev-agent-skills — game-dev skills for AI coding agents. 72 skills and a router across 10 engines, including an art-direction and asset-production workflow.">
 </p>
 
-**67 game-dev skills for your AI coding agent — install once, and a router loads the
+**72 game-dev skills for your AI coding agent — install once, and a router loads the
 right skill for whatever you're building.**
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
-[![Skills](https://img.shields.io/badge/skills-67%20%2B%20router-brightgreen)](skills/)
+[![Skills](https://img.shields.io/badge/skills-72%20%2B%20router-brightgreen)](skills/)
 [![Format](https://img.shields.io/badge/format-Agent%20Skills-informational)](docs/SKILL-FORMAT.md)
 [![Last commit](https://img.shields.io/github/last-commit/gamedev-skills/awesome-gamedev-agent-skills)](https://github.com/gamedev-skills/awesome-gamedev-agent-skills/commits/main)
 
 [Agent Skills](docs/SKILL-FORMAT.md) are small capability files an AI agent loads only when it
-needs them. This repo gives your agent **67 game-dev skills** and a **router** that picks the
+needs them. This repo gives your agent **72 game-dev skills** and a **router** that picks the
 right ones for you. You describe what you're building; the agent loads the matching engine and
 task skills before it writes code.
 
@@ -40,7 +40,7 @@ task skills before it writes code.
 ## Quick start
 
 **One command, any agent.** The [`skills`](https://www.npmjs.com/package/skills) CLI detects the
-coding agent you already use and installs the router plus all 67 skills into the right place:
+coding agent you already use and installs the router plus all 72 skills into the right place:
 
 ```bash
 npx skills add gamedev-skills/awesome-gamedev-agent-skills
@@ -117,7 +117,7 @@ engine), while disciplines, genres, and workflows are additive on top.
 
 ## Catalog
 
-67 skills across 8 categories — each links to its `SKILL.md` below.
+72 skills across 8 categories — each links to its `SKILL.md` below.
 
 ### Engines
 
@@ -176,7 +176,7 @@ engine), while disciplines, genres, and workflows are additive on top.
 | [`threejs-gltf-loading`](skills/web-engines/threejs-gltf-loading/SKILL.md) | Loading glTF/GLB + skinned animation (`GLTFLoader`/`AnimationMixer`) |
 | [`threejs-materials-lighting`](skills/web-engines/threejs-materials-lighting/SKILL.md) | Materials (PBR), lights, shadows, environment maps |
 
-#### Other engines — 5 ([`skills/other-engines/`](skills/other-engines/)) · Bevy · pygame · LÖVE · Roblox
+#### Other engines — 10 ([`skills/other-engines/`](skills/other-engines/)) · Bevy · pygame · LÖVE · Roblox
 
 | Skill | Scope |
 |-------|-------|
@@ -185,6 +185,11 @@ engine), while disciplines, genres, and workflows are additive on top.
 | [`love2d-core`](skills/other-engines/love2d-core/SKILL.md) | LÖVE `load/update/draw` loop, dt-driven motion, input, states (LÖVE 11.5) |
 | [`roblox-luau`](skills/other-engines/roblox-luau/SKILL.md) | Roblox Luau scripting: services, instances, client/server model |
 | [`roblox-datastores`](skills/other-engines/roblox-datastores/SKILL.md) | Persistent data with `DataStoreService`: sessions, limits, ordered stores |
+| [`roblox-ui`](skills/other-engines/roblox-ui/SKILL.md) | Production Roblox UI: responsive Instances, safe insets, input/focus, lifecycle, visual quality |
+| [`roblox-networking`](skills/other-engines/roblox-networking/SKILL.md) | Server-authoritative remotes, validation, rate limits, replication, streaming, prediction |
+| [`roblox-characters`](skills/other-engines/roblox-characters/SKILL.md) | Respawn-safe characters, Humanoids, rigs, movement, animations, tools, cleanup |
+| [`roblox-physics`](skills/other-engines/roblox-physics/SKILL.md) | Assemblies, constraints, collision/query policy, raycasts, forces, network ownership |
+| [`roblox-studio-workflow`](skills/other-engines/roblox-studio-workflow/SKILL.md) | Explorer-first place editing, structure preservation, multi-context Studio verification |
 
 ### Disciplines — 14 ([`skills/disciplines/`](skills/disciplines/))
 
@@ -303,7 +308,7 @@ func _physics_process(delta: float) -> void:
 ## Repository layout
 
 ```
-skills/        67 specialized skills, grouped by engine / discipline / genre / workflow
+skills/        72 specialized skills, grouped by engine / discipline / genre / workflow
 router/        the master router skill (+ references/)
 docs/          authoring standard, installation, compatibility
 templates/     SKILL.md template

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -27,7 +27,7 @@ The [`skills` CLI](https://www.npmjs.com/package/skills) is the package manager 
 Skills ecosystem. It auto-detects your agent(s) and writes skills to each one's directory:
 
 ```bash
-# install the router + all 67 skills into whatever agent(s) you have
+# install the router + all 72 skills into whatever agent(s) you have
 npx skills add gamedev-skills/awesome-gamedev-agent-skills
 
 # preview without installing

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -30,7 +30,7 @@ is the dispatcher). Copy it in alongside the others so the agent can route reque
 
 The [`skills` CLI](https://www.npmjs.com/package/skills) is the package manager for the Agent
 Skills ecosystem. It detects the agents installed on your machine and copies the skills (the
-router plus all 67) into each one's skills directory — no clone required:
+router plus all 72) into each one's skills directory — no clone required:
 
 ```bash
 # install into whatever agent(s) you have
@@ -59,7 +59,7 @@ so you can install it without cloning or copying files. Add the marketplace once
 claude plugin marketplace add gamedev-skills/awesome-gamedev-agent-skills
 ```
 
-Easiest — install the router and all 67 skills in one command:
+Easiest — install the router and all 72 skills in one command:
 
 ```bash
 claude plugin install gamedev@awesome-gamedev-agent-skills

--- a/router/SKILL.md
+++ b/router/SKILL.md
@@ -103,8 +103,10 @@ File signals sharpen this: `*.yarn`/`*.ink` → `dialogue-systems`/`visual-novel
   `unreal-niagara`; ship `unreal-packaging`.
 - **Web** (`skills/web-engines/`): `phaser-core`, `phaser-arcade-physics`; `pixijs-rendering`;
   `threejs-scene-setup`, `threejs-gltf-loading`, `threejs-materials-lighting`.
-- **Other** (`skills/other-engines/`): `bevy-ecs`, `pygame-core`, `love2d-core`, `roblox-luau`,
-  `roblox-datastores`.
+- **Other** (`skills/other-engines/`): `bevy-ecs`, `pygame-core`, `love2d-core`; Roblox foundation
+  `roblox-luau`, persistence `roblox-datastores`, UI `roblox-ui`, remotes/security
+  `roblox-networking`, character lifecycle `roblox-characters`, simulation/queries
+  `roblox-physics`, and in-Studio operation `roblox-studio-workflow`.
 
 ### 3b. Disciplines — load **with** the engine skill (concept ↔ engine API)
 
@@ -124,6 +126,12 @@ File signals sharpen this: `*.yarn`/`*.ink` → `dialogue-systems`/`visual-novel
 | camera follow, deadzone, look-ahead, orbit, first-person | `camera-systems` | `godot-2d-movement` / `godot-3d-essentials` / Cinemachine |
 | HUD, menu, UI layout, scaling, safe area, focus nav | `game-ui-ux` | `godot-ui-control` / Unity UI (UGUI/UI Toolkit) |
 | low FPS, optimize, draw calls, GC spike, pooling, profiler | `performance-optimization` | engine profiler + `physics-tuning` |
+
+For Roblox, compose cross-engine concepts with the focused engine skill: HUD/menu requests use
+`roblox-ui` + `game-ui-ux` (+ `input-systems` for gameplay bindings); remote exploit or
+replication requests use `roblox-networking` + `roblox-luau`; respawn/rig requests use
+`roblox-characters`; physical simulation/query requests use `roblox-physics` (+
+`physics-tuning` for stability); direct place editing also uses `roblox-studio-workflow`.
 
 ### 3c. Genres — **compose** engine + disciplines (bind `*` to the detected engine)
 

--- a/router/references/routing-table.md
+++ b/router/references/routing-table.md
@@ -71,6 +71,11 @@ a real folder at `skills/<category>/<name>/SKILL.md`. Trigger words (`says:`) an
 | `love2d-core` | "LÖVE", "love2d", `love.draw`, `love.update(dt)`; `main.lua`/`conf.lua`/`*.love` |
 | `roblox-luau` | "Roblox", "Luau", `RemoteEvent`, services; `*.luau` + `*.rbxl(x)` / Rojo |
 | `roblox-datastores` | "DataStore", "save player data", `GetDataStore`; `DataStoreService` |
+| `roblox-ui` | Roblox HUD/menu/inventory/shop, `ScreenGui`, `PlayerGui`, `UDim2`, `AutomaticSize`, `GuiService`, UI clipping/respawn, touch/gamepad focus, generic generated UI |
+| `roblox-networking` | Roblox remotes/security/replication, `RemoteEvent`, `RemoteFunction`, `UnreliableRemoteEvent`, exploit, request spam, server authority, desync |
+| `roblox-characters` | Roblox character/respawn/rig/movement/animation, `CharacterAdded`, `Humanoid`, `Animator`, R6/R15, Tool, stale character reference |
+| `roblox-physics` | Roblox assembly/constraint/collision/query/ownership, `RaycastParams`, overlap, `CanQuery`, impulse, BodyMover, projectile/vehicle/knockback |
+| `roblox-studio-workflow` | edit/inspect/test a Roblox place in Studio, Explorer, Script/LocalScript/ModuleScript placement, tags/Attributes, duplicate remotes/systems, Server & Clients, Output |
 
 ## Disciplines (`skills/disciplines/`) — cross-engine concepts, load **with** the engine skill
 

--- a/skills/other-engines/README.md
+++ b/skills/other-engines/README.md
@@ -1,7 +1,7 @@
 # Other engine skills
 
-Five Agent Skills for Bevy 0.19, pygame-ce 2.5.7, LÖVE 11.5, and Roblox
-(Luau plus DataStore persistence).
+Ten Agent Skills for Bevy 0.19, pygame-ce 2.5.7, LÖVE 11.5, and Roblox. Roblox coverage includes
+Luau, persistence, UI, networking, characters, physics, and Studio workflow.
 
 Each subdirectory is one skill. Existing projects keep their pinned engine or
 dependency version; see [`VERSION-SUPPORT.md`](../../docs/VERSION-SUPPORT.md).

--- a/skills/other-engines/roblox-characters/SKILL.md
+++ b/skills/other-engines/roblox-characters/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: roblox-characters
+description: >
+  Build respawn-safe Roblox character systems around Players, CharacterAdded/CharacterRemoving,
+  Humanoid, HumanoidRootPart, Animator, R6/R15 rigs, movement, animations and markers, death,
+  tools, accessories, ownership, and custom characters. Use when character scripts break after
+  respawn, cache stale Humanoids, control movement or velocity, load AnimationTracks, handle death,
+  equip Tools, modify avatars, or support custom player rigs.
+---
+
+# Roblox characters
+
+Treat a `Player` as the durable identity and each `Character` as a replaceable session with its own
+references, connections, animation tracks, and cleanup. Targets Roblox's rolling platform APIs.
+
+## When to use
+
+- Use for player-character lifecycle, Humanoid state/movement, rigs, animations, tools,
+  accessories, custom characters, death, or respawn defects.
+- Use whenever code stores a Character/Humanoid/root reference longer than one spawn.
+
+**When not to use:** general physics queries and constraints belong to `roblox-physics`; remote
+trust belongs to `roblox-networking`; camera logic belongs to `camera-systems`.
+
+## Workflow
+
+1. **Inspect the character contract.** Check avatar settings, `StarterCharacter`,
+   `StarterCharacterScripts`, `CharacterAutoLoads`, R6/R15 support, existing Animate/controller
+   scripts, tools, tags, collision groups, and server/client ownership.
+2. **Separate scopes.** Player-scope state survives respawn; character-scope state does not. Put
+   character connections/tracks/resources in one cleanup scope and destroy it on removal.
+3. **Bind existing and future characters.** Connect `CharacterAdded`, then bind `player.Character`
+   if present. Do not assume event subscription alone sees a character that already spawned.
+4. **Resolve required components defensively.** Wait with a timeout where replication warrants it;
+   validate `Humanoid`, root, `Animator`, and rig assumptions. Abort if that character is no longer
+   current before applying delayed work.
+5. **Choose movement ownership.** Use Humanoid movement for standard avatars; use modern assembly
+   velocity, impulses, or constraints only for mechanics that need physical control. Keep gameplay
+   authority and network ownership implications explicit.
+6. **Own animation lifecycle.** Load via the rig's `Animator`; store tracks/connections; use named
+   markers for gameplay timing only with server validation; stop/disconnect on character cleanup.
+7. **Verify lifecycle stress.** Spawn, die, reset, rapid-respawn, swap rig if supported, equip/drop
+   tools, leave during setup, and run with at least two players when character interactions matter.
+
+## Pattern: replaceable character scope
+
+```lua
+local Players = game:GetService("Players")
+local player = Players.LocalPlayer
+local generation = 0
+local connections: {RBXScriptConnection} = {}
+local currentCharacter: Model? = nil
+
+local function clearCharacter()
+    generation += 1
+    for _, connection in connections do connection:Disconnect() end
+    table.clear(connections)
+    currentCharacter = nil
+end
+
+local function bindCharacter(character: Model)
+    clearCharacter()
+    currentCharacter = character
+    local thisGeneration = generation
+    local humanoid = character:WaitForChild("Humanoid", 10)
+    local root = character:WaitForChild("HumanoidRootPart", 10)
+    if not humanoid or not root or player.Character ~= character then return end
+
+    table.insert(connections, humanoid.Died:Connect(function()
+        if generation ~= thisGeneration then return end
+        setCharacterUiEnabled(false)
+    end))
+    attachCurrentCharacterSystems(character, humanoid, root)
+end
+
+player.CharacterRemoving:Connect(function(character)
+    if currentCharacter == character then clearCharacter() end
+end)
+player.CharacterAdded:Connect(bindCharacter)
+if player.Character then task.defer(bindCharacter, player.Character) end
+```
+
+Use the project's cleanup utility when one exists; do not introduce a new framework for three
+connections. Server systems repeat this binding per `Player` and clear player-scope tables on
+`PlayerRemoving`.
+
+## Pattern: animation through Animator and markers
+
+```lua
+local animation = Instance.new("Animation")
+animation.AnimationId = "rbxassetid://1234567890"
+local track = animator:LoadAnimation(animation)
+local markerConnection = track:GetMarkerReachedSignal("Commit"):Connect(function(parameter)
+    playLocalSwingEffect(parameter) -- presentation; server still validates any hit
+end)
+
+track:Play(0.1)
+-- On character teardown:
+markerConnection:Disconnect()
+track:Stop(0.1)
+animation:Destroy()
+```
+
+For rigs without a `Humanoid`, use an `AnimationController` with an `Animator`. Do not use the
+deprecated convenience path as a substitute for owning the actual Animator and track lifecycle.
+
+## Movement and rig rules
+
+- Do not hardcode R15 limb names if R6 is supported. Prefer attachments, tags, or a rig-type
+  adapter; branch on `Humanoid.RigType` only where topology materially differs.
+- `HumanoidRootPart` is the usual character assembly root, not a universal guarantee for every
+  custom model. Define the custom rig contract and validate it at spawn.
+- Prefer `Humanoid:Move()`/standard controls for ordinary avatar locomotion. Directly changing
+  `AssemblyLinearVelocity` is an instantaneous physical action; use forces/constraints or impulses
+  when continuous or instantaneous physics is the real intent.
+- Never grant damage or movement authority because a client owns its character physics. Validate
+  cross-player consequences on the server.
+- Tools move between Backpack and Character during equip; listen to lifecycle/state rather than
+  assuming one fixed parent. Modify accessories/appearance through current character APIs and
+  preserve an up-to-date applied `HumanoidDescription` when editing avatar appearance.
+
+## Common failures
+
+| Symptom | Likely cause | Remedy |
+|---|---|---|
+| works once, breaks after reset | cached character/Humanoid/root | rebuild per `CharacterAdded`; clear on removal |
+| callbacks fire twice after deaths | old character connections survived | character-scoped cleanup and generation/current checks |
+| delayed load edits wrong rig | async work outlived spawn | compare current Character/generation after every yield |
+| animation visible only locally or not at all | wrong Animator/context/asset ownership | inspect rig Animator, execution side, permissions, and replication |
+| hit marker awards impossible hit | animation marker trusted as authority | use marker for timing/presentation; server validates combat state |
+| R6/custom rig errors | R15 names assumed | define rig contract; attachments/adapter; test each supported rig |
+| tool disappears from system | fixed Backpack/Character parent assumed | handle equip/unequip ancestry and character replacement |
+| custom force fights Humanoid | two controllers own motion | choose one movement authority per state and restore cleanly |
+
+## Resources
+
+- Read `references/lifecycle-and-animation.md` for server binding, death vs removal, rig and
+  animation verification, custom characters, and the lifecycle stress matrix.
+
+## Related skills
+
+- `roblox-physics` — forces, constraints, assemblies, collision, and network ownership.
+- `roblox-networking` — server validation of character actions and stale requests.
+- `input-systems` — action mapping and responsive movement intent.
+- `camera-systems` — camera behavior following replaceable characters.
+
+## Primary references
+
+- `https://create.roblox.com/docs/characters`
+- `https://create.roblox.com/docs/animation/using`
+- `https://create.roblox.com/docs/characters/appearance`

--- a/skills/other-engines/roblox-characters/SKILL.md
+++ b/skills/other-engines/roblox-characters/SKILL.md
@@ -34,8 +34,9 @@ trust belongs to `roblox-networking`; camera logic belongs to `camera-systems`.
 4. **Resolve required components defensively.** Wait with a timeout where replication warrants it;
    validate `Humanoid`, root, `Animator`, and rig assumptions. Abort if that character is no longer
    current before applying delayed work.
-5. **Choose movement ownership.** Use Humanoid movement for standard avatars; use modern assembly
-   velocity, impulses, or constraints only for mechanics that need physical control. Keep gameplay
+5. **Choose movement ownership.** Use Humanoid movement for standard avatars; use
+   `AssemblyLinearVelocity`, `BasePart:ApplyImpulse()`, or a `LinearVelocity`/`AlignPosition`
+   constraint only for mechanics that need physical control. Keep gameplay
    authority and network ownership implications explicit.
 6. **Own animation lifecycle.** Load via the rig's `Animator`; store tracks/connections; use named
    markers for gameplay timing only with server validation; stop/disconnect on character cleanup.
@@ -59,12 +60,16 @@ local function clearCharacter()
 end
 
 local function bindCharacter(character: Model)
+    -- Guard BEFORE teardown. A stale invocation (see the CharacterAdded/defer race below) must not
+    -- clear a binding that is already current, or nothing ends up bound at all.
+    if player.Character ~= character then return end
     clearCharacter()
     currentCharacter = character
     local thisGeneration = generation
     local humanoid = character:WaitForChild("Humanoid", 10)
     local root = character:WaitForChild("HumanoidRootPart", 10)
-    if not humanoid or not root or player.Character ~= character then return end
+    -- Re-check after the yields: a respawn during WaitForChild bumps generation and makes this call stale.
+    if not humanoid or not root or generation ~= thisGeneration then return end
 
     table.insert(connections, humanoid.Died:Connect(function()
         if generation ~= thisGeneration then return end

--- a/skills/other-engines/roblox-characters/agents/openai.yaml
+++ b/skills/other-engines/roblox-characters/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Roblox Characters"
+  short_description: "Build respawn-safe Roblox character systems"
+  default_prompt: "Use $roblox-characters to implement and stress-test this character system."

--- a/skills/other-engines/roblox-characters/references/lifecycle-and-animation.md
+++ b/skills/other-engines/roblox-characters/references/lifecycle-and-animation.md
@@ -1,0 +1,50 @@
+# Character lifecycle and animation verification
+
+Read this when a character system crosses respawns, supports multiple rigs, or owns animation and
+tool resources.
+
+## Durable player, replaceable character
+
+Keep account/session data keyed by `Player`. Keep Humanoid/root/Animator references, tracks,
+character-only state, touch listeners, and character UI bindings inside a spawn scope. The scope
+ends at `CharacterRemoving` or when a newer generation replaces it. `Humanoid.Died` is gameplay
+death; it is not a guaranteed substitute for removal/cleanup.
+
+On the server, bind players already present as well as future players when a Script can start after
+players exist. On the client, subscribe before handling `LocalPlayer.Character` to reduce races.
+After every yield, confirm the player still owns that same character.
+
+## Custom character checklist
+
+- Model/root contract is documented; `PrimaryPart` is set if systems use it.
+- Humanoid rig has required body/root/head/joints; non-Humanoid rig has an
+  `AnimationController`/`Animator` if animated.
+- collision groups, mass, ownership, camera subject, controls, spawn placement, death/reset, tools,
+  attachments, and accessories are deliberately handled.
+- `StarterCharacter` and `CharacterAutoLoads` behavior is tested, including manual loading if used.
+- R6/R15/custom branches are limited to topology differences rather than duplicated systems.
+
+## Animation checks
+
+Verify the animation is owned/usable by the experience, loads on the intended Animator, uses the
+expected priority/looping, blends in/out cleanly, and stops on state exit. Marker names and optional
+parameters must match the authored animation. Store every marker/stopped connection in the same
+scope as the track.
+
+Client-played character animation can provide responsive presentation, but gameplay effects remain
+server-authoritative. For NPC/server-controlled rigs, load/play in the authoritative context chosen
+by the project and verify what all clients observe.
+
+## Lifecycle stress matrix
+
+Test initial spawn, ordinary death, Reset Character, rapid repeated respawn, respawn during delayed
+setup, character replacement without death, tool equipped during death, leave during setup, two
+players dying simultaneously, and every supported rig. Inspect for duplicate callbacks, lingering
+tracks, errors/warnings, stale UI/camera subjects, leftover tagged objects, and player-scope state
+that was incorrectly cleared.
+
+## Primary references
+
+- `https://create.roblox.com/docs/characters`
+- `https://create.roblox.com/docs/animation/using`
+- `https://create.roblox.com/docs/characters/appearance`

--- a/skills/other-engines/roblox-luau/SKILL.md
+++ b/skills/other-engines/roblox-luau/SKILL.md
@@ -24,8 +24,9 @@ Roblox engine and Studio.
   places, or a Rojo `*.project.json`, and code calls `game:GetService(...)`.
 
 **When *not* to use:** persisting data across sessions → `roblox-datastores`.
-Generic Lua questions unrelated to the Roblox API. Engine-agnostic input/save
-architecture → `input-systems` / `save-systems`.
+Remote protocol architecture, exploit hardening, rate limits, high-frequency replication, and
+multi-client abuse testing → `roblox-networking`. Generic Lua questions unrelated to the Roblox
+API. Engine-agnostic input/save architecture → `input-systems` / `save-systems`.
 
 ## Core workflow
 
@@ -189,5 +190,7 @@ print(GameConfig.MaxHealth)
 ## Related skills
 
 - `roblox-datastores` — persist player data across sessions (server-only).
+- `roblox-networking` — production remote contracts, server validation, rate limits, replication,
+  streaming, prediction, and multi-client testing.
 - `save-systems` — engine-agnostic persistence concepts.
 - `game-ai` / `input-systems` — portable AI and input patterns to implement in Luau.

--- a/skills/other-engines/roblox-networking/SKILL.md
+++ b/skills/other-engines/roblox-networking/SKILL.md
@@ -127,7 +127,10 @@ replication. Log aggregate abuse signals, not one warning per rejected packet.
 - With instance streaming, a valid server Instance may not exist on a client. Send a stable ID and
   tolerate absence; do not wait forever for optional streamed content.
 - High-rate cosmetic data may use `UnreliableRemoteEvent`; make each sample self-contained because
-  delivery and order are not guaranteed. Keep payloads well below its documented size limit.
+  delivery and order are not guaranteed. Payloads over **1000 bytes are dropped** (Studio Output
+  reports the overage). `RemoteEvent` and `UnreliableRemoteEvent` also share a throttle of roughly
+  **500 calls/second per client**, counted across all remotes of that type — which is what a
+  legitimate player hits before any attacker does.
 - Predict only latency-sensitive reversible presentation. Include a client sequence/command ID;
   the server returns authoritative state and acknowledgement; the client corrects smoothly. Never
   let prediction award damage, currency, inventory, or progression.

--- a/skills/other-engines/roblox-networking/SKILL.md
+++ b/skills/other-engines/roblox-networking/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: roblox-networking
+description: >
+  Design and harden Roblox client/server networking with RemoteEvent, RemoteFunction, and
+  UnreliableRemoteEvent; server authority, argument and Instance validation, rate limits,
+  proximity/ownership checks, targeted replication, streaming, lifecycle, prediction, and
+  reconciliation. Use for Roblox remotes, exploits, request spam, multiplayer replication,
+  network ownership, high-frequency cosmetic updates, or server/client desynchronization.
+---
+
+# Roblox networking
+
+Build explicit request and replication contracts in which the server decides authoritative game
+state and clients provide input or intent. Targets Roblox's rolling platform APIs. This skill goes
+deeper than the networking primer in `roblox-luau`.
+
+## When to use
+
+- Use to design, implement, debug, or secure cross-boundary Roblox communication.
+- Use when a remote trusts client values, an exploiter can target arbitrary Instances, messages
+  spam services, streamed objects are missing, or clients disagree with the server.
+
+**When not to use:** basic Luau/services belong to `roblox-luau`; persistent state belongs to
+`roblox-datastores`; physical ownership mechanics also compose with `roblox-physics`.
+
+## Workflow
+
+1. **Inspect the existing protocol.** Find every remote and both endpoints; document direction,
+   sender, payload, frequency, authority, validation, and consumers. Reuse the canonical remote
+   folder—do not create a duplicate because discovery was skipped.
+2. **Classify each message.** Client request, server fact, or ephemeral cosmetic sample. Choose
+   reliable event, unreliable event, or request/response from semantics—not convenience.
+3. **Minimize the payload.** Send stable identifiers and intent. Do not send a price, damage,
+   ownership result, arbitrary path, or computed outcome the server can derive.
+4. **Validate in layers.** Check type/shape/finiteness, allowlisted value, Instance class and
+   ancestry, player permissions/state, distance/line of sight where relevant, server cooldown,
+   and rate budget before doing expensive work.
+5. **Apply on the server.** The server resolves targets and mutates health, inventory, currency,
+   cooldowns, and progression. Client-side checks improve UX but grant no trust.
+6. **Replicate narrowly.** Use `FireClient` for private or local facts; broadcast only shared facts.
+   Avoid sending replicated properties again unless the client needs a distinct presentation event.
+7. **Handle time and lifecycle.** Requests may arrive after death, respawn, streaming changes, or
+   disconnect. Resolve the current character/state during handling and clean per-player limiter data.
+8. **Verify with Server & Clients.** Exercise normal, malformed, spam, out-of-range, stale
+   character, rapid respawn, leaving, simultaneous players, targeted, and broadcast cases. Inspect
+   server and each client Output separately.
+
+## Choose the transport
+
+| Primitive | Use | Do not use |
+|---|---|---|
+| `RemoteEvent` | ordered, reliable one-way requests/facts | continuous samples where newer replaces older |
+| `UnreliableRemoteEvent` | ephemeral cosmetic/continuous state tolerant of loss and reordering | purchases, damage decisions, inventory, one-shot state transitions |
+| `RemoteFunction` | bounded client-to-server query that truly needs an immediate reply | server-to-client invocation; long/uncertain work; ordinary commands |
+
+Never invoke a client synchronously from the server. A client may disconnect, error, or never
+return. Prefer server `RemoteEvent:FireClient()` and a separate response event when needed.
+
+## Pattern: validate before resolving gameplay
+
+```lua
+-- ServerScriptService/CombatRequests.server.luau
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Workspace = game:GetService("Workspace")
+
+local attack = ReplicatedStorage.Remotes.Attack
+local lastRequest: {[Player]: number} = {}
+local RANGE = 12
+local COOLDOWN = 0.25
+
+attack.OnServerEvent:Connect(function(player: Player, target: unknown)
+    local now = Workspace:GetServerTimeNow()
+    if now - (lastRequest[player] or -math.huge) < COOLDOWN then return end
+    lastRequest[player] = now
+
+    if typeof(target) ~= "Instance" or not target:IsA("Model") then return end
+    if not target:IsDescendantOf(Workspace.Characters) then return end
+    local targetHumanoid = target:FindFirstChildOfClass("Humanoid")
+    local targetRoot = target:FindFirstChild("HumanoidRootPart")
+    local character = player.Character
+    local root = character and character:FindFirstChild("HumanoidRootPart")
+    local humanoid = character and character:FindFirstChildOfClass("Humanoid")
+    if not targetHumanoid or not targetRoot or not root or not humanoid then return end
+    if humanoid.Health <= 0 or targetHumanoid.Health <= 0 then return end
+    if (root.Position - targetRoot.Position).Magnitude > RANGE then return end
+    if not serverCombatStateAllowsAttack(player, now) then return end
+
+    targetHumanoid:TakeDamage(serverDamageFor(player))
+end)
+
+Players.PlayerRemoving:Connect(function(player)
+    lastRequest[player] = nil
+end)
+```
+
+This is still only a compact example: a real melee system may require server-known attack windows,
+line-of-sight/shape checks, team rules, and lag policy. Do not treat one distance check as security.
+
+## Pattern: token bucket at the boundary
+
+```lua
+type Bucket = {tokens: number, updatedAt: number}
+local buckets: {[Player]: Bucket} = {}
+local CAPACITY, REFILL_PER_SECOND = 6, 3
+
+local function consume(player: Player, cost: number): boolean
+    local now = os.clock()
+    local bucket = buckets[player] or {tokens = CAPACITY, updatedAt = now}
+    bucket.tokens = math.min(CAPACITY,
+        bucket.tokens + (now - bucket.updatedAt) * REFILL_PER_SECOND)
+    bucket.updatedAt = now
+    if bucket.tokens < cost then buckets[player] = bucket; return false end
+    bucket.tokens -= cost
+    buckets[player] = bucket
+    return true
+end
+```
+
+Assign cost by server impact. Reject cheaply before datastore calls, cloning, raycasts, or broad
+replication. Log aggregate abuse signals, not one warning per rejected packet.
+
+## Replication, streaming, and prediction
+
+- Replicated Instances/properties are already a state channel. Use remotes for intent, private
+  state, or presentation cues, not an unconditional parallel copy of the DataModel.
+- With instance streaming, a valid server Instance may not exist on a client. Send a stable ID and
+  tolerate absence; do not wait forever for optional streamed content.
+- High-rate cosmetic data may use `UnreliableRemoteEvent`; make each sample self-contained because
+  delivery and order are not guaranteed. Keep payloads well below its documented size limit.
+- Predict only latency-sensitive reversible presentation. Include a client sequence/command ID;
+  the server returns authoritative state and acknowledgement; the client corrects smoothly. Never
+  let prediction award damage, currency, inventory, or progression.
+- Network ownership improves responsiveness but lets that client influence physical simulation.
+  Validate gameplay consequences on the server; ownership is not authorization.
+
+## Common failures
+
+| Symptom | Likely cause | Remedy |
+|---|---|---|
+| exploiter chooses damage/price | outcome accepted from client | send intent/ID; derive and apply on server |
+| arbitrary object can be deleted | only `typeof(Instance)` checked | validate class, ancestry, ownership, state, and allowlisted operation |
+| server stalls on a player | server invokes client `RemoteFunction` | replace with asynchronous events |
+| valid player triggers throttling | per-frame reliable messages | lower frequency, state replication, batching, or unreliable cosmetics |
+| old packet reverses new effect | unordered unreliable samples treated as commands | make samples replaceable/versioned; use reliable event for transitions |
+| remote breaks after respawn | cached character/root | resolve current character during handling and reject stale state |
+| private data leaks | `FireAllClients` used by default | use `FireClient` and minimal payloads |
+| distance check is bypassed | client-owned object moved near target | anchor/server-own critical object and validate full server context |
+
+## Resources
+
+- Read `references/validation-and-testing.md` for payload rules, Instance/finiteness checks,
+  replication design, and the required multi-client abuse matrix.
+
+## Related skills
+
+- `roblox-luau` — execution locations and basic RemoteEvent mechanics.
+- `roblox-characters` — respawn-safe character resolution.
+- `roblox-physics` — network ownership, ray/overlap validation, and physical consequences.
+- `roblox-studio-workflow` — Server & Clients testing and Output inspection.
+
+## Primary references
+
+- `https://create.roblox.com/docs/scripting/events/remote`
+- `https://create.roblox.com/docs/scripting/security/client-server-boundary`
+- `https://create.roblox.com/docs/physics/network-ownership`
+- `https://create.roblox.com/docs/studio/testing-modes`

--- a/skills/other-engines/roblox-networking/agents/openai.yaml
+++ b/skills/other-engines/roblox-networking/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Roblox Networking"
+  short_description: "Build secure Roblox client-server protocols"
+  default_prompt: "Use $roblox-networking to design and test this Roblox network boundary."

--- a/skills/other-engines/roblox-networking/references/validation-and-testing.md
+++ b/skills/other-engines/roblox-networking/references/validation-and-testing.md
@@ -1,0 +1,64 @@
+# Roblox remote validation and multi-client testing
+
+Read this for a new/changed remote contract or an exploit/desynchronization investigation.
+
+## Contract worksheet
+
+For each message record: remote path; client-to-server/server-to-client; sender; payload schema;
+maximum expected frequency/size; authoritative owner; rejection rules; recipient scope; behavior if
+the player, character, or referenced Instance disappears.
+
+## Validation order
+
+Reject in the cheapest useful order:
+
+1. limiter budget;
+2. argument count and `type`/`typeof`;
+3. numeric finiteness (`value == value` rejects NaN; compare against `math.huge`) and range;
+4. string length and allowlist; table depth/entry count and exact expected keys;
+5. Instance class, ancestry, tag/attribute, current membership, and player ownership;
+6. authoritative player state, cooldown, alive/current character, permission/team;
+7. geometry such as distance, overlap, or line of sight using server-observed state;
+8. only then expensive work and authoritative mutation.
+
+Avoid accepting arbitrary callback names, module/asset IDs, DataModel paths, or Instances for broad
+mutation. A client-visible secret is not a security boundary; renaming/remapping remotes does not
+replace validation.
+
+## Replication choices
+
+Use targeted messages for private inventory, quest details, personal prediction acknowledgements,
+and UI cues visible to one player. Broadcast only world facts all relevant clients need. For nearby
+effects, select recipients on the server rather than broadcasting and asking every client to filter.
+
+An unreliable sample should carry enough state to stand alone and may include a monotonically
+increasing sequence/time so clients can ignore older arrivals. Never split one required logical
+transition across several unreliable messages.
+
+## Required Server & Clients matrix
+
+Run at least two clients where possible and capture server/client Output:
+
+| Case | Expected evidence |
+|---|---|
+| valid request | exactly one server mutation and correct recipient update |
+| wrong type/shape, NaN/huge value | rejected without error or expensive work |
+| unknown or wrong-ancestry Instance | rejected; unrelated Instance unchanged |
+| burst and sustained spam | limiter rejects; server remains responsive; logs bounded |
+| out of range / no permission / cooldown | authoritative state unchanged |
+| character dies or respawns mid-request | stale request rejected; new character works |
+| player leaves during pending work | no stale table entries or callback errors |
+| two simultaneous players | budgets/state remain per player; no cross-target leak |
+| targeted server message | only intended client observes it |
+| broadcast | all connected clients observe once |
+| unreliable cosmetic load | losses/reordering do not corrupt gameplay state |
+
+Do not weaken production validation just to inject malformed calls. Use a Studio-only test harness
+or Command Bar fixture that calls the same pure validator/handler boundary, and remove it after the
+test. Record unexecuted cases explicitly.
+
+## Primary references
+
+- `https://create.roblox.com/docs/scripting/security/client-server-boundary`
+- `https://create.roblox.com/docs/reference/engine/classes/UnreliableRemoteEvent`
+- `https://create.roblox.com/docs/studio/testing-modes`

--- a/skills/other-engines/roblox-physics/SKILL.md
+++ b/skills/other-engines/roblox-physics/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: roblox-physics
+description: >
+  Implement Roblox physical simulation and queries with assemblies, anchoring, constraints,
+  collision groups, CanCollide/CanTouch/CanQuery, raycasts and overlap queries, mass, impulses,
+  forces, velocity, moving assemblies, cleanup, and network ownership. Use for Roblox collisions,
+  hit detection, RaycastParams, PhysicsService, projectiles, vehicles, knockback, constraints,
+  deprecated BodyMovers, unstable motion, or client-owned physics exploits.
+---
+
+# Roblox physics
+
+Choose deliberately between simulation, character control, hit detection, and visual-only motion;
+they are different jobs. Targets Roblox's rolling platform APIs. Pair with `physics-tuning` for
+engine-neutral stability and feel.
+
+## When to use
+
+- Use for BasePart assemblies, constraints, collision/query policy, ray/overlap queries, forces,
+  impulses, moving physical objects, network ownership, or physics cleanup.
+- Use when `Touched` is unreliable/security-sensitive, parts tunnel or jitter, a mechanism breaks
+  when anchored, or old BodyMover patterns appear.
+
+**When not to use:** ordinary Humanoid lifecycle/control belongs to `roblox-characters`; remote
+validation belongs to `roblox-networking`; decorative UI/world motion may only need a tween.
+
+## Decide the system first
+
+| Goal | Mechanism |
+|---|---|
+| sustained physical interaction | unanchored assembly + modern constraints/forces |
+| instantaneous physical change | `ApplyImpulse` / `ApplyAngularImpulse` |
+| kinematic platform/path | controlled pivot/transform with an explicit passenger policy |
+| character locomotion | Humanoid/custom character controller (`roblox-characters`) |
+| authoritative hit test | server raycast/overlap with filters and gameplay validation |
+| cosmetic trail/recoil | local visual motion; no gameplay authority |
+
+## Workflow
+
+1. **Inspect the mechanism.** In Studio, visualize assemblies, anchors, constraints, collision
+   groups, massless parts, and network owners. Identify the assembly root and intended authority.
+2. **Define interaction policy.** Write the collision-group matrix and separately decide
+   `CanCollide`, `CanTouch`, and `CanQuery`. These flags are not interchangeable.
+3. **Choose simulation or query.** Do not use `.Touched` as a universal hit detector. Use a ray for
+   a path/line, an overlap query for a volume, and simulation contacts when physical response is
+   actually required.
+4. **Apply motion at assembly level.** Forces on a part affect its assembly. Use modern
+   `LinearVelocity`, `AngularVelocity`, `VectorForce`, `AlignPosition`, and `AlignOrientation`
+   constraints as appropriate; migrate deprecated BodyMovers when changing that system.
+5. **Set ownership deliberately.** Server-own gameplay-critical loose assemblies when required;
+   client ownership can improve responsiveness but never authorizes gameplay results.
+6. **Bound cost and lifetime.** Reuse query parameters, cap query frequency/result count, remove
+   temporary constraints/attachments, and disconnect event listeners.
+7. **Verify under load and multiplayer.** Test anchored/unanchored transitions, mass extremes,
+   collision matrix, fast motion, multiple clients, ownership changes, streaming, and cleanup.
+
+## Pattern: filtered server raycast
+
+```lua
+local Workspace = game:GetService("Workspace")
+
+local params = RaycastParams.new()
+params.FilterType = Enum.RaycastFilterType.Exclude
+params.FilterDescendantsInstances = {shooterCharacter}
+params.IgnoreWater = true
+params.CollisionGroup = "WeaponQuery"
+
+local direction = aimDirection.Unit * MAX_RANGE
+local result = Workspace:Raycast(muzzlePosition, direction, params)
+if result then
+    local model = result.Instance:FindFirstAncestorOfClass("Model")
+    local humanoid = model and model:FindFirstChildOfClass("Humanoid")
+    if humanoid and serverCanDamage(shooter, model, result.Position) then
+        humanoid:TakeDamage(serverWeaponDamage(shooter))
+    end
+end
+```
+
+The server must validate the origin/direction against server-known character/weapon state; do not
+accept an arbitrary client origin and treat the raycast itself as validation.
+
+## Pattern: overlap volume with explicit policy
+
+```lua
+local params = OverlapParams.new()
+params.FilterType = Enum.RaycastFilterType.Exclude
+params.FilterDescendantsInstances = {sourceCharacter}
+params.CollisionGroup = "DamageQuery"
+params.MaxParts = 64
+
+local seen: {[Model]: boolean} = {}
+for _, part in Workspace:GetPartBoundsInBox(hitboxCFrame, hitboxSize, params) do
+    local model = part:FindFirstAncestorOfClass("Model")
+    if model and not seen[model] then
+        seen[model] = true
+        validateAndApplyHit(model)
+    end
+end
+```
+
+Bounds queries use bounding boxes and can include multiple parts from one target; deduplicate and
+perform exact/gameplay checks as needed. For exact geometry use the appropriate precise overlap API
+only when its additional cost is justified.
+
+## Assemblies, force, and ownership
+
+- Welded parts form one rigid assembly; force, impulse, velocity, mass, and ownership operate on
+  that assembly. Anchoring a part changes simulation/ownership and can make an assembly effectively
+  infinite mass.
+- Apply an impulse for a one-time change; use a force or velocity constraint for sustained control.
+  Setting `AssemblyLinearVelocity` is an immediate state change, not a continuous force model.
+- Prefer attachments plus modern constraints over `BodyPosition`, `BodyVelocity`, `BodyGyro`, and
+  other deprecated BodyMovers when authoring or revising a mechanism.
+- Automatic ownership may move nearby unanchored assemblies to clients. Use
+  `SetNetworkOwner(nil)` conservatively for critical objects, then measure responsiveness/server
+  cost. Visualize network owners in Studio.
+- A client owner can manipulate physical results and `.Touched` observations. The server validates
+  consequential hits, positions, timing, and permissions independently.
+
+## Common failures
+
+| Symptom | Likely cause | Remedy |
+|---|---|---|
+| welded mechanism will not move | one part anchored | inspect full assembly; anchor only intentional world roots |
+| force behaves too strongly/weakly | assembly mass ignored | inspect `AssemblyMass`; tune force/impulse by intended acceleration |
+| hit misses fast projectile | discrete touch sampling/tunneling | swept ray/shape query and `physics-tuning`; do not rely only on `.Touched` |
+| ray hits shooter/effects | filters/collision group absent | reuse explicit params and query group |
+| same target damaged many times | overlap returned multiple body parts | deduplicate by target model and enforce attack ID/cooldown |
+| exploit fires impossible touch | client owns relevant physics | server query/context validation; deliberate ownership |
+| invisible trigger blocks or cannot query | three flags conflated | set `CanCollide`, `CanTouch`, `CanQuery` independently |
+| mechanism leaks attachments | temporary constraint lifecycle missing | own and destroy constraints, attachments, and connections together |
+
+## Resources
+
+- Read `references/queries-and-ownership.md` for collision/query matrices, assembly debugging,
+  ownership security, migration choices, and the physics verification matrix.
+
+## Related skills
+
+- `physics-tuning` — timestep, jitter, tunneling, mass ratios, and stability methodology.
+- `roblox-characters` — Humanoid/custom movement and respawn lifecycle.
+- `roblox-networking` — authoritative validation of client-requested physical actions.
+- `roblox-studio-workflow` — visualization, Output, and multi-client verification.
+
+## Primary references
+
+- `https://create.roblox.com/docs/physics/assemblies`
+- `https://create.roblox.com/docs/physics/network-ownership`
+- `https://create.roblox.com/docs/workspace/raycasting`

--- a/skills/other-engines/roblox-physics/SKILL.md
+++ b/skills/other-engines/roblox-physics/SKILL.md
@@ -99,8 +99,10 @@ end
 ```
 
 Bounds queries use bounding boxes and can include multiple parts from one target; deduplicate and
-perform exact/gameplay checks as needed. For exact geometry use the appropriate precise overlap API
-only when its additional cost is justified.
+perform exact/gameplay checks as needed. For exact geometry use `WorldRoot:GetPartsInPart(part, overlapParams)`
+only when its additional cost is justified. Note `OverlapParams.RespectCanCollide` decides whether a
+query honours `CanCollide` or `CanQuery` — set it deliberately, or it silently overrides the flag
+policy below. `OverlapParams.Tolerance` controls contact slop.
 
 ## Assemblies, force, and ownership
 
@@ -123,7 +125,7 @@ only when its additional cost is justified.
 |---|---|---|
 | welded mechanism will not move | one part anchored | inspect full assembly; anchor only intentional world roots |
 | force behaves too strongly/weakly | assembly mass ignored | inspect `AssemblyMass`; tune force/impulse by intended acceleration |
-| hit misses fast projectile | discrete touch sampling/tunneling | swept ray/shape query and `physics-tuning`; do not rely only on `.Touched` |
+| hit misses fast projectile | discrete touch sampling/tunneling | swept query — `WorldRoot:Blockcast()`, `Spherecast()`, or `Shapecast()` — plus `physics-tuning`; do not rely only on `.Touched` |
 | ray hits shooter/effects | filters/collision group absent | reuse explicit params and query group |
 | same target damaged many times | overlap returned multiple body parts | deduplicate by target model and enforce attack ID/cooldown |
 | exploit fires impossible touch | client owns relevant physics | server query/context validation; deliberate ownership |

--- a/skills/other-engines/roblox-physics/agents/openai.yaml
+++ b/skills/other-engines/roblox-physics/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Roblox Physics"
+  short_description: "Build secure Roblox physics and queries"
+  default_prompt: "Use $roblox-physics to implement and verify this Roblox physics system."

--- a/skills/other-engines/roblox-physics/references/queries-and-ownership.md
+++ b/skills/other-engines/roblox-physics/references/queries-and-ownership.md
@@ -1,0 +1,57 @@
+# Roblox physics queries, collision policy, and ownership
+
+Read this when designing collision groups, query filters, a physical gameplay object, or a
+multiplayer ownership/security test.
+
+## Separate the three flags
+
+`CanCollide` controls physical response, `CanTouch` controls touch event participation, and
+`CanQuery` controls spatial-query eligibility (subject to query parameters). Define each by role.
+Typical sensor parts do not collide but may touch/query; visual-only geometry may do neither. Use
+named collision groups through `PhysicsService` and verify the actual matrix in Studio.
+
+## Query selection
+
+- `Workspace:Raycast(origin, direction, params)` for the first surface along a segment. Direction
+  magnitude is range.
+- sphere/block radius/bounds overlap methods for broad volume candidates. Deduplicate assemblies or
+  target models and refine if bounding-box false positives matter.
+- configure `RaycastParams`/`OverlapParams` with include/exclude instances, collision group, water,
+  and result bounds. Reuse params where the filter is stable; update it when character generations
+  or streamed containers change.
+
+Query results are evidence, not a whole gameplay authorization. Also validate actor state, team,
+cooldown, origin, target membership, and permissions on the server.
+
+## Assembly and ownership debugging
+
+In Studio, inspect `AssemblyRootPart`, `AssemblyMass`, center of mass, anchors, constraints, and the
+Network Owners visualization. Test automatic ownership before forcing it. Server ownership protects
+simulation authority but can increase server work and latency; client ownership improves response
+but requires server validation of consequences.
+
+When a mechanism changes anchor state, re-check ownership because prior ownership state may not be
+retained. For vehicles, explicitly decide which occupant should own the assembly and what happens
+on seat changes, death, or disconnect.
+
+## Modern motion migration
+
+Map sustained linear control to `LinearVelocity` or `VectorForce`, rotational control to
+`AngularVelocity`/`Torque`, and pose following to `AlignPosition`/`AlignOrientation`. Preserve the
+old system's coordinate space, force/torque limits, attachment geometry, reaction force, and
+ownership behavior; do not replace class names without measuring behavior.
+
+## Verification matrix
+
+Test one part and a welded multi-part assembly; anchored/unanchored transitions; intended collision
+group pairs; each Can* flag; fast and slow movers; low/high mass; ray miss/hit/filter edge; overlap
+deduplication and max-result behavior; client approaching/leaving automatic ownership; explicit
+owner disconnect/death; two clients interacting simultaneously; streaming absence; and complete
+temporary-object cleanup. Use server-observed results for gameplay assertions.
+
+## Primary references
+
+- `https://create.roblox.com/docs/physics/assemblies`
+- `https://create.roblox.com/docs/physics/network-ownership`
+- `https://create.roblox.com/docs/workspace/raycasting`
+- `https://create.roblox.com/docs/reference/engine/datatypes/RaycastParams`

--- a/skills/other-engines/roblox-studio-workflow/SKILL.md
+++ b/skills/other-engines/roblox-studio-workflow/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: roblox-studio-workflow
+description: >
+  Modify living Roblox Studio projects safely: inspect Explorer and execution locations, preserve
+  existing structure, reuse modules/remotes, create meaningful Instances, apply Attributes and
+  CollectionService tags, test server/client and multiple devices, inspect Output, and remove
+  experiments/debug objects. Use when an agent edits a place or rbxl/rbxlx/Rojo project, operates
+  in Studio, adds Scripts/LocalScripts/ModuleScripts, or must verify a Roblox change in context.
+---
+
+# Roblox Studio workflow
+
+Work as a collaborator inside an existing place, not as if it were a blank text repository. Targets
+current Roblox Studio and rolling platform APIs.
+
+## When to use
+
+- Use before invasive edits to a Roblox place, Studio DataModel, or Rojo-backed project.
+- Use to plan execution location, find/reuse systems, create editable Instances, and gather honest
+  Studio verification evidence.
+
+**When not to use:** this skill owns project operation, not the domain implementation. Compose it
+with `roblox-ui`, `roblox-networking`, `roblox-characters`, `roblox-physics`, `roblox-luau`, or
+`roblox-datastores` as appropriate.
+
+## Workflow
+
+1. **Establish source of truth.** Determine whether Studio, Rojo files, a package manager, or a
+   generated build owns each subtree. Do not hand-edit generated output or create Studio-only
+   changes that the next sync overwrites.
+2. **Inventory before proposing structure.** Inspect Explorer, search scripts/modules/remotes/tags,
+   read project mapping and naming conventions, and run once to observe existing warnings. Locate
+   the feature's current owner and dependencies.
+3. **Plan the smallest compatible edit.** Name the Instances and execution locations you will
+   change. Reuse existing remotes, component modules, cleanup utilities, tags, Attributes, folders,
+   and configuration patterns. State any unresolved ownership boundary.
+4. **Create real, meaningful objects.** Normal authored UI, folders, attachments, constraints,
+   remotes, and configuration remain inspectable in Explorer. Use scripts for behavior and truly
+   dynamic repetition—not to hide the entire feature in runtime construction.
+5. **Respect execution and replication.** Put authoritative logic in server containers, persistent
+   client logic in `StarterPlayerScripts`, per-character client logic in
+   `StarterCharacterScripts`, UI templates in `StarterGui`, shared assets/modules/remotes in
+   `ReplicatedStorage`, and secrets/server assets in server-only containers.
+6. **Test the actual risk.** Choose Play, Play Here, Run, Server & Clients, Device Emulator,
+   Controller Emulator, or scripted Studio testing based on the behavior. Inspect server and client
+   Output, not only the viewport.
+7. **Clean the experiment.** Remove temporary parts, test remotes, command-bar scripts, debug UI,
+   prints, disabled duplicate scripts, placeholder assets, and tags/Attributes created only for
+   diagnosis. Stop the session and confirm edit-mode hierarchy is clean.
+8. **Report evidence precisely.** List changed Instances/files, modes and client counts, cases
+   executed, observed Output, failures and fixes, and anything not run. Never translate “looks
+   plausible” or static inspection into “tested in Studio.”
+
+## Execution-location map
+
+| Location | Typical role | Key constraint |
+|---|---|---|
+| `ServerScriptService` | authoritative server Scripts/modules | not replicated to clients |
+| `ServerStorage` | server-only assets/data | clients cannot access it |
+| `ReplicatedStorage` | shared modules/assets/remotes | visible to clients; do not store secrets |
+| `StarterPlayerScripts` | client systems across respawns | clone into `PlayerScripts` |
+| `StarterCharacterScripts` | per-character client behavior | recreated each character |
+| `StarterGui` | authored UI templates | clones into `PlayerGui`; lifecycle depends on GUI policy |
+| `Workspace` | replicated world and live characters | streaming/ownership may affect client view |
+
+Verify actual Script `RunContext` and project conventions; class/location shorthand does not excuse
+inspection of an existing custom setup.
+
+## Reuse before adding
+
+Before creating a RemoteEvent, search by purpose and inspect both endpoints. Before adding a
+“manager” or service module, identify the current feature owner. Before introducing folders/tags,
+inspect naming and retrieval patterns. Duplicate systems are especially dangerous when both run:
+they double-bind input, save twice, create two UI clones, or apply gameplay twice.
+
+Use Attributes for small typed designer-editable metadata that belongs on an Instance. Use
+`CollectionService` tags for discovering sets of Instances across hierarchy. Use folders for
+ownership/navigation, not as a substitute for semantic tags. Preserve established schemas and
+validate missing/malformed Attributes at system boundaries.
+
+```lua
+local CollectionService = game:GetService("CollectionService")
+
+local function setupDoor(instance: Instance)
+    if not instance:IsA("Model") then return end
+    local accessLevel = instance:GetAttribute("AccessLevel")
+    if type(accessLevel) ~= "number" then
+        warn(`Door {instance:GetFullName()} needs numeric AccessLevel`)
+        return
+    end
+    attachDoorBehavior(instance, accessLevel)
+end
+
+for _, door in CollectionService:GetTagged("Door") do setupDoor(door) end
+CollectionService:GetInstanceAddedSignal("Door"):Connect(setupDoor)
+```
+
+The owning system must also clean behavior when a tagged Instance is removed/destroyed.
+
+## Verification ladder
+
+1. **Static:** project mapping/JSON/XML parses; links resolve; Luau diagnostics/lint if available.
+2. **Single session:** correct execution context, hierarchy, no new Output errors/warnings, basic
+   happy path and cleanup.
+3. **Lifecycle:** respawn, reset, reopen/rejoin, streaming or character replacement as relevant.
+4. **Server & Clients:** at least two clients for remotes, replication, ownership, player
+   interaction, joins/leaves, and targeted state.
+5. **Device/input:** representative device profiles, orientation, touch, controller navigation.
+6. **Stress/failure:** malformed input, spam, empty/full content, rapid transitions, simultaneous
+   actions, disconnects, and cleanup.
+
+Use the smallest rungs that cover the change, but never substitute a lower rung for a claimed
+higher-rung result.
+
+## Common failures
+
+| Symptom | Likely cause | Remedy |
+|---|---|---|
+| Studio edit disappears after sync | generated/mapped subtree edited | change source-of-truth files and resync |
+| feature runs twice | duplicate Script/remote/controller | inspect first; consolidate under existing owner |
+| client cannot access module/object | wrong execution/storage location | move shared content deliberately; keep secrets server-only |
+| authored screen unreadable in Explorer | everything created by one LocalScript | create named Instance shell and small behavior modules |
+| test passes only in Play | replication/lifecycle untested | use Server & Clients and relevant emulators |
+| “clean” Output hides client errors | only server Output inspected | inspect each client and server context |
+| shipped place has DebugFolder/prints | experiment cleanup skipped | maintain cleanup list and inspect hierarchy after session |
+| Attribute/tag behavior silently fails | schema/class not validated | validate at setup boundary; warn with full Instance path |
+
+## Resources
+
+- Read `references/studio-verification.md` before reporting Studio validation or when choosing test
+  modes, constructing a temporary harness, or documenting an automation gap.
+
+## Related skills
+
+- `roblox-luau` — services, Instances, events, and basic execution model.
+- `roblox-ui`, `roblox-networking`, `roblox-characters`, `roblox-physics` — focused production
+  workflows that use this inspection and verification discipline.
+
+## Primary references
+
+- `https://create.roblox.com/docs/studio/testing-modes`
+- `https://create.roblox.com/docs/projects/data-model`
+- `https://create.roblox.com/docs/scripting/services`

--- a/skills/other-engines/roblox-studio-workflow/agents/openai.yaml
+++ b/skills/other-engines/roblox-studio-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Roblox Studio Workflow"
+  short_description: "Inspect, modify, and verify living Roblox places"
+  default_prompt: "Use $roblox-studio-workflow to inspect and safely change this Roblox project."

--- a/skills/other-engines/roblox-studio-workflow/references/studio-verification.md
+++ b/skills/other-engines/roblox-studio-workflow/references/studio-verification.md
@@ -1,0 +1,59 @@
+# Roblox Studio verification evidence
+
+Read this before claiming a change was tested in Studio.
+
+## Select modes by risk
+
+- **Run**: server/world behavior without a player.
+- **Play / Play Here**: quick integrated player path or spawn-location context.
+- **Server & Clients**: separate server and up to multiple clients; required for meaningful remote,
+  ownership, targeted replication, join/leave, and simultaneous-player checks.
+- **Device Emulator**: resolutions, orientation, DPI/device constraints, touch simulation, and
+  streaming behavior under representative device conditions.
+- **Controller Emulator**: input mappings and gamepad UI navigation.
+- **Studio-only scripted testing services**: automation where the installed Studio/API and project
+  tooling expose observable results; do not invent a headless workflow.
+
+## Evidence record
+
+For each run record Studio version/date, place/build source, mode, client count, emulated device or
+controller, setup, action, expected result, observed result, relevant server/client Output, and
+pass/fail. Screenshots help visual review but do not replace interaction or Output evidence.
+
+Separate verification levels explicitly:
+
+- **Executed:** observed in a running Studio session with Output/result evidence.
+- **Statically checked:** parsed, linted, type-checked, or inspected without engine execution.
+- **Prepared, not run:** an exact scenario/harness exists but requires manual Studio interaction.
+- **Unverified:** no adequate check was possible.
+
+Never collapse the latter three into “Studio tested.”
+
+## Temporary harness rules
+
+Keep a harness isolated and easy to remove. It may expose a pure validator or create representative
+instances, but must call the production boundary rather than reimplement it. Guard Studio-only
+fixtures so they cannot run in a published server. Remove test remotes, Parts, scripts, tags,
+Attributes, debug UI, and logs before final hierarchy review.
+
+## UI quality scenario
+
+For an inventory/HUD/settings evaluation, author a real `ScreenGui` hierarchy with header, primary
+content, secondary detail, repeated-item template, and action/footer region. Populate empty, small,
+and overflow datasets. Verify desktop, narrow portrait, mobile landscape, tablet-like, and console;
+mouse hover/press, touch activation, gamepad focus and scroll-follow; safe insets; long text;
+disabled/error state; open/close interruption; respawn/reset policy; and Explorer readability.
+
+Reject and revise if visual hierarchy depends on universal rounded cards, random gradients/neon,
+oversized headings, excessive empty space/transparency/blur, identical action hierarchy, or noisy
+motion. Fix the skill guidance—not only the fixture—when the output followed an underspecified rule.
+
+## Networking scenario
+
+Use at least two clients for valid, malformed, spam, out-of-range, stale character, leave during
+work, rapid respawn, simultaneous requests, targeted response, and broadcast. Check authoritative
+state in server context and visibility in every client, plus limiter/cleanup state after leave.
+
+## Primary reference
+
+- `https://create.roblox.com/docs/studio/testing-modes`

--- a/skills/other-engines/roblox-studio-workflow/references/studio-verification.md
+++ b/skills/other-engines/roblox-studio-workflow/references/studio-verification.md
@@ -11,8 +11,9 @@ Read this before claiming a change was tested in Studio.
 - **Device Emulator**: resolutions, orientation, DPI/device constraints, touch simulation, and
   streaming behavior under representative device conditions.
 - **Controller Emulator**: input mappings and gamepad UI navigation.
-- **Studio-only scripted testing services**: automation where the installed Studio/API and project
-  tooling expose observable results; do not invent a headless workflow.
+- **`TestService`**: Studio-only scripted assertions (`TestService:Check()`, `Require()`,
+  `Message()`, `Fail()`) surfaced in the Output/TestService pane. Use it where the installed
+  Studio/API and project tooling expose observable results; do not invent a headless workflow.
 
 ## Evidence record
 

--- a/skills/other-engines/roblox-ui/SKILL.md
+++ b/skills/other-engines/roblox-ui/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: roblox-ui
+description: >
+  Build production Roblox interfaces with ScreenGui/PlayerGui lifecycle, responsive UDim2
+  layouts, safe insets, reusable editable Instances, cross-device input and selection, restrained
+  motion, cleanup, and multi-viewport verification. Use for Roblox HUDs, inventories, shops,
+  settings, ability bars, ScrollingFrames, AutomaticSize, GuiService, gamepad focus, touch UI, or
+  UI that clips, resets on respawn, looks generic, or was generated as one giant LocalScript.
+---
+
+# Roblox UI
+
+Implement deliberate, editable Roblox UI that preserves the experience's visual language and
+works across supported devices. Targets Roblox's rolling platform APIs. Pair with `game-ui-ux`
+for engine-neutral information architecture and UX; this skill owns Roblox Instances and APIs.
+
+## When to use
+
+- Use for authored `ScreenGui` interfaces, Roblox layout/constraint APIs, UI lifecycle, input,
+  focus, animation, performance, or responsive/device fixes.
+- Use to replace brittle pixel layouts, runtime-created Instance tangles, mouse-only menus, or
+  generic generated styling with a maintainable hierarchy.
+
+**When not to use:** general UX flow and accessibility principles belong to `game-ui-ux`; raw
+gameplay action mapping belongs to `input-systems`; server trust belongs to `roblox-networking`.
+
+## Workflow
+
+1. **Inspect before designing.** In Explorer, inventory existing `ScreenGui`s, UI modules,
+   fonts, colors, icon family, spacing, corners, strokes, animation timing, naming, and reusable
+   components. Capture representative screenshots at two viewports. Extend that language.
+2. **Define ownership and lifecycle.** `StarterGui` is the authored template; Roblox clones it
+   into each player's `PlayerGui`. Decide whether each `ScreenGui` should persist across respawn
+   with `ResetOnSpawn = false`; never keep stale references to a destroyed clone.
+3. **Author a readable hierarchy.** Prefer meaningful editable Instances and small behavior
+   modules. A normal screen should be understandable in Explorer; procedural generation is for
+   genuinely data-driven repetition, not the whole shell.
+4. **Build responsive structure.** Combine `UDim2` scale for placement with bounded offsets,
+   correct `AnchorPoint`s, layouts, padding, content sizing, and constraints. Choose explicit
+   narrow/wide arrangements instead of shrinking a desktop panel until it technically fits.
+5. **Handle platform obstructions.** Keep interactive UI in `CoreUISafeInsets` (the recommended
+   `ScreenGui.ScreenInsets` default), and account for touch controls and TV distance/overscan.
+6. **Wire state and input.** Render from a small view state; update on events. Use `Activated` for
+   `GuiButton`s, explicit selected states, and reachable gamepad navigation. Bind non-widget
+   actions with `ContextActionService` only while the screen owns them.
+7. **Polish with restraint.** Implement hover, pressed, selected, and disabled states. Animate
+   state changes, not decoration; honor `GuiService.ReducedMotionEnabled` and clean up tweens and
+   connections when the screen closes or is replaced.
+8. **Verify the real interface.** Use Device Emulator and Controller Emulator. Test desktop,
+   narrow portrait, mobile landscape, tablet-like, and console/gamepad; then respawn. Record
+   clipping, overlap, text, scroll, safe-area, focus path, touch target, and lifecycle results.
+
+## Production structure
+
+```text
+StarterGui
+└── InventoryGui (ScreenGui; ResetOnSpawn = false)
+    ├── Root (Frame)
+    │   ├── Header
+    │   ├── Content
+    │   │   ├── CategoryList
+    │   │   ├── ItemGrid (ScrollingFrame)
+    │   │   └── DetailsPanel
+    │   └── Footer
+    └── InventoryController (LocalScript)
+ReplicatedStorage
+└── UI
+    ├── Components
+    └── Theme
+```
+
+Names describe roles, not colors or temporary positions. Keep repeated item cells as templates or
+components, but keep the authored shell visible in Explorer.
+
+## Patterns
+
+### Layout that survives content and viewport changes
+
+```lua
+-- Authored properties on ItemGrid (ScrollingFrame):
+--   AutomaticCanvasSize = Enum.AutomaticSize.Y
+--   CanvasSize = UDim2.fromOffset(0, 0)
+-- Children: UIPadding + UIGridLayout
+local grid = itemGrid.UIGridLayout
+local projectBreakpoint = 700 -- derive from where this composition stops being usable
+
+local function applyComposition()
+    local narrow = root.AbsoluteSize.X < projectBreakpoint
+    categoryList.UIListLayout.FillDirection = if narrow
+        then Enum.FillDirection.Horizontal
+        else Enum.FillDirection.Vertical
+    categoryList.Size = if narrow
+        then UDim2.new(1, 0, 0, 40)
+        else UDim2.new(0, 148, 1, 0)
+    itemGrid.Position = if narrow then UDim2.fromOffset(0, 52) else UDim2.fromOffset(164, 0)
+    itemGrid.Size = if narrow
+        then UDim2.new(1, 0, 1, -52)
+        else UDim2.new(0.58, -164, 1, 0)
+    detailsPanel.Visible = not narrow -- open details as a separate narrow-screen state
+
+    local width = itemGrid.AbsoluteSize.X
+    local columns = if width < 520 then 2 elseif width < 820 then 3 else 4
+    local gap = 12
+    local usable = width - itemGrid.UIPadding.PaddingLeft.Offset
+        - itemGrid.UIPadding.PaddingRight.Offset - gap * (columns - 1)
+    grid.CellSize = UDim2.fromOffset(math.floor(usable / columns), 112)
+    grid.CellPadding = UDim2.fromOffset(gap, gap)
+end
+
+root:GetPropertyChangedSignal("AbsoluteSize"):Connect(applyComposition)
+applyComposition()
+```
+
+Use `UIListLayout` for one-dimensional flow, `UIGridLayout` for uniform cells, and
+`UITableLayout` only when row/column alignment is truly tabular. `AutomaticSize` fits content;
+`AutomaticCanvasSize` fits scroll content. Bound extremes with `UISizeConstraint`,
+`UIAspectRatioConstraint`, or `UITextSizeConstraint` rather than one global `UIScale` guess.
+
+### One activation path and explicit gamepad entry
+
+```lua
+local GuiService = game:GetService("GuiService")
+local RunService = game:GetService("RunService")
+local UserInputService = game:GetService("UserInputService")
+
+local function openInventory()
+    root.Visible = true
+    task.spawn(function()
+        RunService.RenderStepped:Wait() -- selection must be rendered and selectable
+        if root.Visible and (UserInputService.GamepadEnabled
+            or (UserInputService.KeyboardEnabled and not UserInputService.TouchEnabled)) then
+            GuiService.SelectedObject = firstItemButton
+        end
+    end)
+end
+
+local function closeInventory()
+    GuiService.SelectedObject = nil
+    root.Visible = false
+end
+
+firstItemButton.Activated:Connect(function()
+    selectItem(firstItemButton:GetAttribute("ItemId"))
+end)
+```
+
+Prefer `Activated` over separate mouse/touch handlers. Set `NextSelectionUp/Down/Left/Right`
+when automatic navigation is ambiguous, especially around grids, sidebars, and modals. A modal
+must trap focus inside itself and restore a sensible selection when it closes.
+
+Inspect Roblox's default selection adornment in context. If it overwhelms the interface, assign a
+project-owned `SelectionImageObject` or selected-state treatment; keep it visible, valid, and
+restrained rather than disabling focus feedback.
+
+### State transition without animation noise
+
+```lua
+local TweenService = game:GetService("TweenService")
+local GuiService = game:GetService("GuiService")
+local fade = TweenInfo.new(0.14, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+
+local function setPanelVisible(visible: boolean)
+    panel.Visible = true -- panel is a CanvasGroup
+    if GuiService.ReducedMotionEnabled then
+        panel.GroupTransparency = if visible then 0 else 1
+    else
+        TweenService:Create(panel, fade, {
+            GroupTransparency = if visible then 0 else 1,
+        }):Play()
+    end
+    if not visible then
+        task.delay(fade.Time, function()
+            if panel.GroupTransparency == 1 then panel.Visible = false end
+        end)
+    end
+end
+```
+
+Animate a panel or state boundary once. Do not independently bounce every descendant.
+
+## Visual quality gates
+
+- Establish hierarchy through size, weight, contrast, grouping, and whitespace before adding
+  decoration. Use a small spacing scale and align to it.
+- Preserve the game's fonts, palette, icons, radii, and strokes. If none exist, define a compact
+  token module; do not improvise per component.
+- Use corners where the material/form calls for them, not on every nested `Frame`. Avoid nested
+  card-on-card shells, universal pills, arbitrary gradients/glows/shadows, neon outlines,
+  excessive transparency/blur, oversized headings, meaningless icons, and huge empty panels.
+- Buttons with different importance should not look identical. Define primary, secondary,
+  quiet, destructive, selected, pressed, hover, and disabled treatment only as needed.
+- Motion communicates open/close, focus, confirmation, or spatial relationship. Keep it short,
+  interruptible, and subtle; avoid perpetual motion and decorative tween chains.
+- On touch devices, reserve the default movement/jump corners. Move or recompose bottom actions
+  that overlap them, and hide keyboard/gamepad hints when those inputs are not active.
+
+## Common failures
+
+| Symptom | Likely cause | Remedy |
+|---|---|---|
+| UI disappears or duplicates after respawn | wrong `ResetOnSpawn` policy or stale clone | choose policy; reacquire from `PlayerGui`; clean old bindings |
+| Phone layout clips | desktop offsets/global scale used as layout | add narrow composition, layouts, bounds, and Device Emulator checks |
+| Content hidden under topbar/notch | insets ignored or `ScreenInsets = None` | use `CoreUISafeInsets` for interactive UI; inspect intentional bleed |
+| Scroll ends early | fixed `CanvasSize` | use `AutomaticCanvasSize` or layout `AbsoluteContentSize` |
+| Controller gets stuck | no entry selection or bad neighbor graph | set initial `SelectedObject`; define and test focus edges/modal trap |
+| UI looks generated | decoration substituted for hierarchy | remove effects; align, reduce nesting, fix density and component roles |
+| Explorer contains only one script | entire authored interface is procedural | author the shell as named Instances; generate repeated content only |
+| Increasing connection/tween count | screen rebinds without cleanup | own connections per screen lifecycle; disconnect/cancel on teardown |
+
+## Resources
+
+- Read `references/responsive-layout.md` for layout decisions, inset policy, density, and the
+  required viewport matrix.
+- Read `references/input-navigation.md` when implementing gamepad/touch focus, modal behavior,
+  action binding, or motion preferences.
+- Build `assets/inventory-quality-test.project.json` with Rojo (it maps the adjacent JSON model)
+  for an editable Instance fixture used in visual/layout review; it is a test baseline, not a style
+  template for a shipping game.
+
+## Related skills
+
+- `game-ui-ux` — information hierarchy, screen flow, accessibility, and UX validation.
+- `input-systems` — gameplay action mapping and device switching.
+- `roblox-networking` — server-authoritative requests initiated by UI.
+- `roblox-studio-workflow` — Explorer-first editing and Studio verification.
+
+## Primary references
+
+- Roblox Creator Hub: `https://create.roblox.com/docs/ui/on-screen-containers`
+- Roblox Creator Hub: `https://create.roblox.com/docs/ui/position-and-size`
+- Roblox Creator Hub: `https://create.roblox.com/docs/ui/size-modifiers`
+- Roblox Creator Hub: `https://create.roblox.com/docs/studio/testing-modes`

--- a/skills/other-engines/roblox-ui/agents/openai.yaml
+++ b/skills/other-engines/roblox-ui/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Roblox UI"
+  short_description: "Build responsive production Roblox interfaces"
+  default_prompt: "Use $roblox-ui to implement and verify this Roblox interface."

--- a/skills/other-engines/roblox-ui/assets/inventory-quality-test.model.json
+++ b/skills/other-engines/roblox-ui/assets/inventory-quality-test.model.json
@@ -1,0 +1,330 @@
+{
+  "ClassName": "ScreenGui",
+  "Properties": {
+    "ResetOnSpawn": false,
+    "ScreenInsets": "CoreUISafeInsets",
+    "ZIndexBehavior": "Sibling"
+  },
+  "Children": [
+    {
+      "Name": "Root",
+      "ClassName": "Frame",
+      "Properties": {
+        "AnchorPoint": [0.5, 0.5],
+        "Position": {"UDim2": [[0.5, 0], [0.5, 0]]},
+        "Size": {"UDim2": [[0.82, 0], [0.78, 0]]},
+        "BackgroundColor3": [0.0706, 0.0824, 0.102],
+        "BorderSizePixel": 0
+      },
+      "Children": [
+        {
+          "ClassName": "UISizeConstraint",
+          "Properties": {
+            "MinSize": [320, 360],
+            "MaxSize": [1120, 720]
+          }
+        },
+        {
+          "ClassName": "UICorner",
+          "Properties": {"CornerRadius": {"UDim": [0, 10]}}
+        },
+        {
+          "ClassName": "UIStroke",
+          "Properties": {
+            "Color": [0.1804, 0.2118, 0.2588],
+            "Thickness": 1,
+            "Transparency": 0.2
+          }
+        },
+        {
+          "ClassName": "UIPadding",
+          "Properties": {
+            "PaddingTop": {"UDim": [0, 20]},
+            "PaddingBottom": {"UDim": [0, 16]},
+            "PaddingLeft": {"UDim": [0, 20]},
+            "PaddingRight": {"UDim": [0, 20]}
+          }
+        },
+        {
+          "Name": "Header",
+          "ClassName": "Frame",
+          "Properties": {
+            "Size": {"UDim2": [[1, 0], [0, 56]]},
+            "BackgroundTransparency": 1
+          },
+          "Children": [
+            {
+              "Name": "Title",
+              "ClassName": "TextLabel",
+              "Properties": {
+                "Size": {"UDim2": [[0.65, 0], [1, 0]]},
+                "BackgroundTransparency": 1,
+                "Text": "INVENTORY",
+                "TextColor3": [0.9412, 0.949, 0.9647],
+                "TextSize": 24,
+                "Font": "GothamBold",
+                "TextXAlignment": "Left"
+              }
+            },
+            {
+              "Name": "Capacity",
+              "ClassName": "TextLabel",
+              "Properties": {
+                "AnchorPoint": [1, 0.5],
+                "Position": {"UDim2": [[1, 0], [0.5, 0]]},
+                "Size": {"UDim2": [[0, 120], [0, 28]]},
+                "BackgroundTransparency": 1,
+                "Text": "18 / 24 slots",
+                "TextColor3": [0.5686, 0.6157, 0.6902],
+                "TextSize": 14,
+                "Font": "Gotham",
+                "TextXAlignment": "Right"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "Content",
+          "ClassName": "Frame",
+          "Properties": {
+            "Position": {"UDim2": [[0, 0], [0, 64]]},
+            "Size": {"UDim2": [[1, 0], [1, -120]]},
+            "BackgroundTransparency": 1
+          },
+          "Children": [
+            {
+              "Name": "CategoryList",
+              "ClassName": "Frame",
+              "Properties": {
+                "Size": {"UDim2": [[0, 132], [1, 0]]},
+                "BackgroundTransparency": 1
+              },
+              "Children": [
+                {
+                  "ClassName": "UIListLayout",
+                  "Properties": {
+                    "Padding": {"UDim": [0, 6]},
+                    "SortOrder": "LayoutOrder"
+                  }
+                },
+                {
+                  "Name": "All",
+                  "ClassName": "TextButton",
+                  "Properties": {
+                    "Size": {"UDim2": [[1, 0], [0, 38]]},
+                    "BackgroundColor3": [0.1373, 0.1725, 0.2314],
+                    "BorderSizePixel": 0,
+                    "Text": "All items",
+                    "TextColor3": [0.9412, 0.949, 0.9647],
+                    "TextSize": 14,
+                    "Font": "GothamMedium",
+                    "TextXAlignment": "Left",
+                    "SelectionOrder": 1
+                  }
+                },
+                {
+                  "Name": "Weapons",
+                  "ClassName": "TextButton",
+                  "Properties": {
+                    "Size": {"UDim2": [[1, 0], [0, 38]]},
+                    "BackgroundTransparency": 1,
+                    "Text": "Weapons",
+                    "TextColor3": [0.6745, 0.7098, 0.7647],
+                    "TextSize": 14,
+                    "Font": "Gotham",
+                    "TextXAlignment": "Left",
+                    "SelectionOrder": 2
+                  }
+                },
+                {
+                  "Name": "Consumables",
+                  "ClassName": "TextButton",
+                  "Properties": {
+                    "Size": {"UDim2": [[1, 0], [0, 38]]},
+                    "BackgroundTransparency": 1,
+                    "Text": "Consumables",
+                    "TextColor3": [0.6745, 0.7098, 0.7647],
+                    "TextSize": 14,
+                    "Font": "Gotham",
+                    "TextXAlignment": "Left",
+                    "SelectionOrder": 3
+                  }
+                }
+              ]
+            },
+            {
+              "Name": "ItemGrid",
+              "ClassName": "ScrollingFrame",
+              "Properties": {
+                "Position": {"UDim2": [[0, 148], [0, 0]]},
+                "Size": {"UDim2": [[0.58, -148], [1, 0]]},
+                "BackgroundTransparency": 1,
+                "BorderSizePixel": 0,
+                "AutomaticCanvasSize": "Y",
+                "CanvasSize": {"UDim2": [[0, 0], [0, 0]]},
+                "ScrollBarThickness": 4
+              },
+              "Children": [
+                {
+                  "ClassName": "UIGridLayout",
+                  "Properties": {
+                    "CellSize": {"UDim2": [[0.5, -6], [0, 112]]},
+                    "CellPadding": {"UDim2": [[0, 12], [0, 12]]},
+                    "SortOrder": "LayoutOrder"
+                  }
+                },
+                {
+                  "Name": "FieldKnife",
+                  "ClassName": "TextButton",
+                  "Properties": {
+                    "BackgroundColor3": [0.102, 0.1216, 0.1529],
+                    "BorderSizePixel": 0,
+                    "Text": "FIELD KNIFE\nLight · Equipped",
+                    "TextColor3": [0.9176, 0.9294, 0.949],
+                    "TextSize": 14,
+                    "Font": "GothamMedium",
+                    "TextWrapped": true,
+                    "SelectionOrder": 10
+                  },
+                  "Children": [
+                    {
+                      "ClassName": "UIStroke",
+                      "Properties": {"Color": [0.2902, 0.5137, 0.7765], "Thickness": 2}
+                    }
+                  ]
+                },
+                {
+                  "Name": "Medkit",
+                  "ClassName": "TextButton",
+                  "Properties": {
+                    "BackgroundColor3": [0.102, 0.1216, 0.1529],
+                    "BorderSizePixel": 0,
+                    "Text": "MEDKIT\nRestores 50 health",
+                    "TextColor3": [0.9176, 0.9294, 0.949],
+                    "TextSize": 14,
+                    "Font": "GothamMedium",
+                    "TextWrapped": true,
+                    "SelectionOrder": 11
+                  }
+                },
+                {
+                  "Name": "SignalFlare",
+                  "ClassName": "TextButton",
+                  "Properties": {
+                    "BackgroundColor3": [0.102, 0.1216, 0.1529],
+                    "BorderSizePixel": 0,
+                    "Text": "SIGNAL FLARE\n3 remaining",
+                    "TextColor3": [0.9176, 0.9294, 0.949],
+                    "TextSize": 14,
+                    "Font": "GothamMedium",
+                    "TextWrapped": true,
+                    "SelectionOrder": 12
+                  }
+                },
+                {
+                  "Name": "Rope",
+                  "ClassName": "TextButton",
+                  "Properties": {
+                    "BackgroundColor3": [0.102, 0.1216, 0.1529],
+                    "BorderSizePixel": 0,
+                    "Text": "CLIMBING ROPE\nUtility",
+                    "TextColor3": [0.9176, 0.9294, 0.949],
+                    "TextSize": 14,
+                    "Font": "GothamMedium",
+                    "TextWrapped": true,
+                    "SelectionOrder": 13
+                  }
+                }
+              ]
+            },
+            {
+              "Name": "DetailsPanel",
+              "ClassName": "Frame",
+              "Properties": {
+                "AnchorPoint": [1, 0],
+                "Position": {"UDim2": [[1, 0], [0, 0]]},
+                "Size": {"UDim2": [[0.38, -12], [1, 0]]},
+                "BackgroundColor3": [0.0902, 0.1059, 0.1333],
+                "BorderSizePixel": 0
+              },
+              "Children": [
+                {
+                  "ClassName": "UIPadding",
+                  "Properties": {
+                    "PaddingTop": {"UDim": [0, 18]},
+                    "PaddingBottom": {"UDim": [0, 18]},
+                    "PaddingLeft": {"UDim": [0, 18]},
+                    "PaddingRight": {"UDim": [0, 18]}
+                  }
+                },
+                {
+                  "Name": "ItemName",
+                  "ClassName": "TextLabel",
+                  "Properties": {
+                    "Size": {"UDim2": [[1, 0], [0, 32]]},
+                    "BackgroundTransparency": 1,
+                    "Text": "Field Knife",
+                    "TextColor3": [0.9412, 0.949, 0.9647],
+                    "TextSize": 20,
+                    "Font": "GothamBold",
+                    "TextXAlignment": "Left"
+                  }
+                },
+                {
+                  "Name": "Description",
+                  "ClassName": "TextLabel",
+                  "Properties": {
+                    "Position": {"UDim2": [[0, 0], [0, 44]]},
+                    "Size": {"UDim2": [[1, 0], [0, 92]]},
+                    "BackgroundTransparency": 1,
+                    "Text": "A balanced utility blade. Quick to ready and quiet in close quarters.",
+                    "TextColor3": [0.6745, 0.7098, 0.7647],
+                    "TextSize": 14,
+                    "Font": "Gotham",
+                    "TextWrapped": true,
+                    "TextXAlignment": "Left",
+                    "TextYAlignment": "Top"
+                  }
+                },
+                {
+                  "Name": "Equip",
+                  "ClassName": "TextButton",
+                  "Properties": {
+                    "AnchorPoint": [0, 1],
+                    "Position": {"UDim2": [[0, 0], [1, 0]]},
+                    "Size": {"UDim2": [[1, 0], [0, 44]]},
+                    "BackgroundColor3": [0.2902, 0.5137, 0.7765],
+                    "BorderSizePixel": 0,
+                    "Text": "Equip item",
+                    "TextColor3": [1, 1, 1],
+                    "TextSize": 15,
+                    "Font": "GothamBold",
+                    "SelectionOrder": 20
+                  },
+                  "Children": [
+                    {"ClassName": "UICorner", "Properties": {"CornerRadius": {"UDim": [0, 6]}}}
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Name": "Footer",
+          "ClassName": "TextLabel",
+          "Properties": {
+            "AnchorPoint": [0, 1],
+            "Position": {"UDim2": [[0, 0], [1, 0]]},
+            "Size": {"UDim2": [[1, 0], [0, 36]]},
+            "BackgroundTransparency": 1,
+            "Text": "A Select     B Close     LB/RB Categories",
+            "TextColor3": [0.4902, 0.5373, 0.6078],
+            "TextSize": 13,
+            "Font": "Gotham",
+            "TextXAlignment": "Left"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/skills/other-engines/roblox-ui/assets/inventory-quality-test.model.json
+++ b/skills/other-engines/roblox-ui/assets/inventory-quality-test.model.json
@@ -166,6 +166,15 @@
               },
               "Children": [
                 {
+                  "ClassName": "UIPadding",
+                  "Properties": {
+                    "PaddingTop": {"UDim": [0, 4]},
+                    "PaddingBottom": {"UDim": [0, 4]},
+                    "PaddingLeft": {"UDim": [0, 4]},
+                    "PaddingRight": {"UDim": [0, 4]}
+                  }
+                },
+                {
                   "ClassName": "UIGridLayout",
                   "Properties": {
                     "CellSize": {"UDim2": [[0.5, -6], [0, 112]]},

--- a/skills/other-engines/roblox-ui/assets/inventory-quality-test.project.json
+++ b/skills/other-engines/roblox-ui/assets/inventory-quality-test.project.json
@@ -1,0 +1,12 @@
+{
+  "name": "RobloxUIQualityTest",
+  "tree": {
+    "$className": "DataModel",
+    "StarterGui": {
+      "$className": "StarterGui",
+      "InventoryGui": {
+        "$path": "inventory-quality-test.model.json"
+      }
+    }
+  }
+}

--- a/skills/other-engines/roblox-ui/references/input-navigation.md
+++ b/skills/other-engines/roblox-ui/references/input-navigation.md
@@ -1,0 +1,76 @@
+# Roblox UI input, selection, and motion
+
+Read this for gamepad navigation, touch/mouse parity, modal focus, `ContextActionService`, or UI
+motion. Targets Roblox's rolling platform APIs.
+
+## Control contract
+
+- Prefer `GuiButton.Activated` for the primary action because it unifies mouse, touch, and gamepad.
+- Give every interactive state a visual response: hover where a pointer exists, pressed, selected,
+  disabled, and busy if an operation can take time. Do not communicate state with color alone.
+- Make touch targets comfortably hittable and separated; do not add invisible hit zones that overlap
+  neighboring controls.
+- Show input prompts that match the active device, but never hide the only explanation of an action
+  during device switching.
+
+## Selection graph
+
+On screen open, select the most likely safe action—not a destructive action. Use
+`GuiService.SelectedObject`. Let automatic selection handle simple lists; assign
+`NextSelectionLeft/Right/Up/Down` where layout geometry is ambiguous. Test every edge and a full
+round trip through the graph.
+
+Set initial selection only after the control is rendered and only for keyboard/gamepad navigation.
+Device emulation can expose keyboard capability while touch controls are active, so prefer the
+active input policy used by the project; do not force a selected object on a touch-first screen.
+Inspect the default adornment. A custom `SelectionImageObject` must remain a valid visible
+`GuiObject` (it can live offscreen as the reusable template) and should match the interface's focus
+treatment instead of adding a large glow.
+
+When a modal opens:
+
+1. remember the prior selected object if it still belongs to the underlying screen;
+2. prevent interaction with the screen beneath it;
+3. select the modal's first safe control;
+4. keep directional navigation inside the modal;
+5. on close, restore the prior object or a stable fallback.
+
+Use `GuiService:AddSelectionParent`/`AddSelectionTuple` only after checking current API status;
+some older selection-group methods are deprecated. Prefer explicit navigation properties and
+current selection APIs when they solve the screen.
+
+## Context actions
+
+Use `ContextActionService:BindAction()` for screen-level actions such as close/back, tab change, or
+an ability-bar shortcut that is not already owned by a button. Bind on screen activation and
+`UnbindAction()` on close. Return `Enum.ContextActionResult.Sink` only when the UI intentionally
+consumes the action; otherwise allow gameplay to receive it.
+
+Do not create a second input system inside a menu. Coordinate screen actions with `input-systems`
+and preserve the project's existing action names and bindings.
+
+## Motion lifecycle
+
+- Read `GuiService.ReducedMotionEnabled`; replace spatial movement with an instant state or short
+  opacity change when reduced motion is requested.
+- Reuse a small timing/easing vocabulary. Typical state transitions should be quick enough not to
+  delay interaction.
+- Cancel or supersede an in-flight tween when the target state changes. Do not queue contradictory
+  open/close animations.
+- Animate a stable parent (`CanvasGroup` is useful for group transparency) instead of spawning a
+  tween for every descendant.
+- The logical state changes immediately; animation visualizes it. Never make server-critical state
+  depend on tween completion.
+
+## Controller verification
+
+Use Studio's Controller Emulator and also a real controller when available. Verify initial focus,
+all directions, activation, back/cancel, tab/shoulder navigation if used, scroll-following selected
+items, focus restoration, and mouse-to-gamepad switching. Controller emulation proves mapping and
+navigation, not TV legibility; use Device Emulator/console sizing for that.
+
+## Primary references
+
+- `https://create.roblox.com/docs/reference/engine/classes/GuiService`
+- `https://create.roblox.com/docs/studio/testing-modes`
+- `https://create.roblox.com/docs/production/publishing/console-guidelines`

--- a/skills/other-engines/roblox-ui/references/input-navigation.md
+++ b/skills/other-engines/roblox-ui/references/input-navigation.md
@@ -35,9 +35,10 @@ When a modal opens:
 4. keep directional navigation inside the modal;
 5. on close, restore the prior object or a stable fallback.
 
-Use `GuiService:AddSelectionParent`/`AddSelectionTuple` only after checking current API status;
-some older selection-group methods are deprecated. Prefer explicit navigation properties and
-current selection APIs when they solve the screen.
+To keep directional navigation inside the modal, set `GuiBase2d.SelectionGroup = true` on the modal
+root and set its `SelectionBehaviorUp`/`Down`/`Left`/`Right` to `Enum.SelectionBehavior.Stop`. The
+older `GuiService:AddSelectionParent()`/`AddSelectionTuple()`/`RemoveSelectionGroup()` methods are
+all deprecated — do not use them in new work.
 
 ## Context actions
 

--- a/skills/other-engines/roblox-ui/references/responsive-layout.md
+++ b/skills/other-engines/roblox-ui/references/responsive-layout.md
@@ -33,8 +33,10 @@ author's primary monitor. This reference targets Roblox's rolling platform APIs.
 
 For interactive `ScreenGui` content, retain `ScreenInsets = CoreUISafeInsets` unless the design
 has a measured reason not to. Decorative backgrounds may intentionally bleed into `None`, but put
-interactive descendants in a separate inset-aware `ScreenGui` or safe root. `GuiService:GetInsetArea()`
-provides actual inset rectangles when custom positioning needs them.
+interactive descendants in a separate inset-aware `ScreenGui` or safe root.
+`GuiService:GetInsetArea(Enum.ScreenInsets.CoreUISafeInsets)` returns the actual inset rectangle when
+custom positioning needs it — the `ScreenInsets` argument is required, and which inset set you ask
+for is the point of the call. `GuiService.TopbarInset` gives the topbar rectangle on its own.
 
 Mobile tests must include the bottom-left movement control and bottom-right jump/action region.
 Console tests must consider viewing distance and overscan, not just a desktop window enlarged to TV

--- a/skills/other-engines/roblox-ui/references/responsive-layout.md
+++ b/skills/other-engines/roblox-ui/references/responsive-layout.md
@@ -1,0 +1,84 @@
+# Responsive Roblox UI
+
+Read this when a screen must adapt across viewport sizes or when layout defects appear outside the
+author's primary monitor. This reference targets Roblox's rolling platform APIs.
+
+## Choose structure before coordinates
+
+1. Identify persistent regions: HUD edge groups, header, primary content, secondary detail,
+   footer/action row, modal layer.
+2. Decide what changes on narrow screens. Reflow or collapse secondary regions; do not only scale
+   the desktop composition down.
+3. Anchor edge-owned regions to their edge (`AnchorPoint` must match `Position`). Put siblings in
+   layouts instead of manually positioning each child.
+4. Use offsets for bounded component dimensions and spacing; use scale for proportional placement
+   and flexible region size. Inspect `AbsoluteSize`, not device names, for layout breakpoints.
+
+## Roblox layout primitives
+
+| Need | Primitive | Check |
+|---|---|---|
+| vertical/horizontal flow | `UIListLayout` | `Padding`, alignment, flex behavior, content size |
+| uniform collection | `UIGridLayout` | cell size at narrow/wide bounds; scroll canvas |
+| true rows and columns | `UITableLayout` | headers and cell alignment; avoid for card collections |
+| inner spacing | `UIPadding` | use one spacing scale; include it in width calculations |
+| content-driven object | `AutomaticSize` | localization, wrapping, and circular dependencies |
+| content-driven scrolling | `AutomaticCanvasSize` | scrolling direction and bottom reachability |
+| proportional shape/media | `UIAspectRatioConstraint` | avoid constraining text-heavy containers |
+| min/max component size | `UISizeConstraint` | test both limits, not only preferred width |
+| bounded text scaling | `UITextSizeConstraint` | still test localization and TV distance |
+| deliberate subtree zoom | `UIScale` | avoid using one scale as the entire responsive system |
+
+## Safe areas and reserved controls
+
+For interactive `ScreenGui` content, retain `ScreenInsets = CoreUISafeInsets` unless the design
+has a measured reason not to. Decorative backgrounds may intentionally bleed into `None`, but put
+interactive descendants in a separate inset-aware `ScreenGui` or safe root. `GuiService:GetInsetArea()`
+provides actual inset rectangles when custom positioning needs them.
+
+Mobile tests must include the bottom-left movement control and bottom-right jump/action region.
+Console tests must consider viewing distance and overscan, not just a desktop window enlarged to TV
+resolution.
+
+Do not choose breakpoints from device labels. Choose them where the composition loses usable width:
+for example, a sidebar + grid + detail view must switch to a horizontal category strip, full-width
+grid, and separate detail state before any region becomes token-width. On touch, relocate bottom
+actions away from reserved controls and remove irrelevant controller hint rows.
+
+## Density and visual rhythm
+
+Derive a small spacing scale from the existing game (for example 4/8/12/16/24, not a mandated
+universal scale). Reuse it for padding, gaps, icon-to-label space, and section separation. A larger
+gap signals a stronger grouping boundary. Choose text roles (title, section, body, metadata) and
+keep role sizes/weights stable. Use consistent icon boxes even when source art has different bounds.
+
+## Required verification matrix
+
+| Configuration | Inspect |
+|---|---|
+| desktop, mouse + keyboard | hover/pressed, resizing, ultrawide or tall extreme |
+| narrow mobile portrait | reflow, touch reach, wrapping, scrolling, safe cutouts |
+| mobile landscape | reserved controls, low vertical space, modal height |
+| tablet-like | density and excessive empty space |
+| console/gamepad | initial focus, every directional edge, back action, TV readability |
+
+For every configuration, exercise open/close, content-empty/content-full, long localized-like text,
+disabled and error states, scrolling to both ends, and character respawn. Record observed defects
+and the exact change that fixed them.
+
+## Bundled Instance fixture
+
+`../assets/inventory-quality-test.project.json` maps the adjacent Rojo JSON model into `StarterGui`.
+Build it with `rojo build assets/inventory-quality-test.project.json -o inventory-test.rbxlx` from
+the skill directory. The result contains a real `ScreenGui` hierarchy—not a procedural UI script.
+Inspect it in Explorer, then use it only to exercise the matrix above. It deliberately uses
+restrained geometry and a clear category/grid/detail hierarchy; adaptation logic, interaction
+behavior, data population, and project styling remain work for the test scenario. Do not ship the
+fixture unchanged.
+
+## Primary references
+
+- `https://create.roblox.com/docs/ui/on-screen-containers`
+- `https://create.roblox.com/docs/ui/position-and-size`
+- `https://create.roblox.com/docs/ui/size-modifiers`
+- `https://create.roblox.com/docs/production/publishing/adaptive-design`


### PR DESCRIPTION
## Summary

- add focused Roblox skills for UI, networking, characters, physics, and Studio workflows
- route advanced remote work from `roblox-luau` to `roblox-networking`
- update the router, marketplace bundles, catalog, installation docs, and skill counts

## Why

The existing Roblox skills cover core Luau scripting and DataStore persistence. These additions give UI, networking, character lifecycle, physics, and Studio testing their own routing targets instead of expanding one general-purpose skill.

## Validation

- `python scripts/validate-skills.py`
  - validated 73 skill files and repository wiring
- `python -m unittest discover -s tests -v`
  - all 12 tests passed
- `python scripts/generate-site.py`
  - generated 90 pages for 72 skills
- `python scripts/check-site.py`
  - all site checks passed
- `git diff --check`
  - passed

All Luau examples were checked with the Luau parser.

Roblox Studio testing covered responsive UI across desktop, phone, tablet, and Xbox layouts; keyboard navigation; character respawning; remote validation and rate limiting; physics queries, impulses, and network ownership.

A two-client Studio test also passed, with both clients completing separate server-issued handshakes.

## Maintainer note

A dedicated Roblox folder would make this group easier to navigate as it grows. The current repository contract requires skills to live directly under `skills/<category>/<skill-name>/`, so this PR keeps them under `skills/other-engines/roblox-*`.

A future repository-wide layout change could add first-class engine subfolders with matching validator, router, and marketplace support.